### PR TITLE
perf: cleanup redundant point allocations and native calls

### DIFF
--- a/src/MacroTools/ArtifactSystem/ArtifactManager.cs
+++ b/src/MacroTools/ArtifactSystem/ArtifactManager.cs
@@ -96,6 +96,8 @@ public static class ArtifactManager
           return;
         }
 
+        var triggerUnitPosition = triggerUnit.GetPosition();
+
         bool? isPositionPathable = null;
         for (var i = 0; i < 6; i++)
         {
@@ -111,15 +113,15 @@ public static class ArtifactManager
             continue;
           }
 
-          isPositionPathable ??= !pathingtype.Walkability.GetPathable(triggerUnit.X, triggerUnit.Y);
+          isPositionPathable ??= !pathingtype.Walkability.GetPathable(triggerUnitPosition.X, triggerUnitPosition.Y);
 
           if (isPositionPathable == true)
           {
-            itemInSlot.SetPosition(triggerUnit.GetPosition());
+            itemInSlot.SetPosition(triggerUnitPosition.X, triggerUnitPosition.Y);
           }
           else
           {
-            var shore = ShoreManager.GetNearestShore(triggerUnit.GetPosition());
+            var shore = ShoreManager.GetNearestShore(triggerUnitPosition);
             if (shore == null)
             {
               throw new InvalidOperationException(

--- a/src/MacroTools/DummyCasters/LongLivedDummyCaster.cs
+++ b/src/MacroTools/DummyCasters/LongLivedDummyCaster.cs
@@ -30,7 +30,7 @@ public sealed class LongLivedDummyCaster
   /// </summary>
   public void ChannelAtCaster(unit caster, int abilityId, int orderId, int level, float duration)
   {
-    var newUnit = unit.Create(caster.Owner, _unitTypeId, caster.GetPosition().X, caster.GetPosition().Y, 0);
+    var newUnit = unit.Create(caster.Owner, _unitTypeId, caster.X, caster.Y, 0);
     newUnit.AddAbility(abilityId);
     newUnit.SetAbilityLevel(abilityId, level);
     newUnit.IssueOrder(orderId);

--- a/src/MacroTools/Extensions/UnitExtensions.cs
+++ b/src/MacroTools/Extensions/UnitExtensions.cs
@@ -391,8 +391,7 @@ public static class UnitExtensions
   /// </summary>
   public static void FacePosition(this unit whichUnit, Point targetPoint)
   {
-    var unitPosition = whichUnit.GetPosition();
-    var facing = WCSharp.Shared.Util.AngleBetweenPoints(unitPosition.X, unitPosition.Y, targetPoint.X, targetPoint.Y);
+    var facing = WCSharp.Shared.Util.AngleBetweenPoints(whichUnit.X, whichUnit.Y, targetPoint.X, targetPoint.Y);
     whichUnit.Facing = facing;
   }
 

--- a/src/MacroTools/Hazards/SolarJudgementHazard.cs
+++ b/src/MacroTools/Hazards/SolarJudgementHazard.cs
@@ -1,7 +1,6 @@
 ﻿using MacroTools.Libraries;
 using MacroTools.SpellSystem;
 using MacroTools.Utils;
-using WCSharp.Shared.Data;
 
 namespace MacroTools.Hazards;
 
@@ -18,7 +17,7 @@ public sealed class SolarJudgementHazard : Hazard
   private void DoBolt(float x, float y)
   {
     effect.Create(EffectPath, x, y).Dispose();
-    var unitsInRange = GlobalGroup.EnumUnitsInRange(new Point(x, y), BoltRadius);
+    var unitsInRange = GlobalGroup.EnumUnitsInRange(x, y, BoltRadius);
     foreach (var target in unitsInRange)
     {
       if (CastFilters.IsTargetEnemyAndAlive(Caster, target))

--- a/src/MacroTools/Mechanics/DemonGates/DemonGateBuff.cs
+++ b/src/MacroTools/Mechanics/DemonGates/DemonGateBuff.cs
@@ -45,8 +45,7 @@ public sealed class DemonGateBuff : TickingBuff
         return FocalDemonGateBuff.Instance.SpawnPoint;
       }
 
-      var targetPosition = Target.GetPosition();
-      var (x, y) = Util.PositionWithPolarOffset(targetPosition.X, targetPosition.Y, SpawnDistance, Target.Facing + FacingOffset);
+      var (x, y) = Util.PositionWithPolarOffset(Target.X, Target.Y, SpawnDistance, Target.Facing + FacingOffset);
       return new Point(x, y);
     }
   }

--- a/src/MacroTools/Mechanics/DemonGates/FocalDemonGateBuff.cs
+++ b/src/MacroTools/Mechanics/DemonGates/FocalDemonGateBuff.cs
@@ -25,8 +25,7 @@ public sealed class FocalDemonGateBuff : PassiveBuff
   {
     get
     {
-      var targetPosition = Target.GetPosition();
-      var (x, y) = Util.PositionWithPolarOffset(targetPosition.X, targetPosition.Y, SpawnDistance, Target.Facing + FacingOffset);
+      var (x, y) = Util.PositionWithPolarOffset(Target.X, Target.Y, SpawnDistance, Target.Facing + FacingOffset);
       return new Point(x, y);
     }
   }

--- a/src/MacroTools/ObjectiveSystem/Objectives/ControlPointBased/ObjectiveControlPoint.cs
+++ b/src/MacroTools/ObjectiveSystem/Objectives/ControlPointBased/ObjectiveControlPoint.cs
@@ -66,8 +66,11 @@ public sealed class ObjectiveControlPoint : Objective
 
   private void RegisterKillTriggers(float range)
   {
+    var target = _target.Unit;
+    var targetX = target.X;
+    var targetY = target.Y;
     var unitsNearby = GlobalGroup
-      .EnumUnitsInRange(_target.Unit.GetPosition(), range)
+      .EnumUnitsInRange(targetX, targetY, range)
         .Where(x => x.Owner == player.NeutralAggressive && !x.IsUnitType(unittype.Ancient) &&
          !x.IsUnitType(unittype.Sapper) && !x.IsUnitType(unittype.Structure));
 

--- a/src/MacroTools/PassiveAbilities/CreateCorpseOnDeath.cs
+++ b/src/MacroTools/PassiveAbilities/CreateCorpseOnDeath.cs
@@ -1,5 +1,4 @@
-﻿using MacroTools.Extensions;
-using MacroTools.PassiveAbilitySystem;
+﻿using MacroTools.PassiveAbilitySystem;
 
 namespace MacroTools.PassiveAbilities;
 
@@ -38,10 +37,9 @@ public sealed class CreateCorpseOnDeath : PassiveAbility, IEffectOnDeath
       return;
     }
 
-    var pos = triggerUnit.GetPosition();
     for (var i = 0; i < CorpseCount; i++)
     {
-      unit.CreateCorpse(triggerUnit.Owner, CorpseUnitTypeId, pos.X, pos.Y, triggerUnit.Facing);
+      unit.CreateCorpse(triggerUnit.Owner, CorpseUnitTypeId, triggerUnit.X, triggerUnit.Y, triggerUnit.Facing);
     }
 
     triggerUnit.Dispose();

--- a/src/MacroTools/PassiveAbilities/CreateUnitOnDeath.cs
+++ b/src/MacroTools/PassiveAbilities/CreateUnitOnDeath.cs
@@ -48,14 +48,16 @@ public sealed class CreateUnitOnDeath : PassiveAbility, IEffectOnDeath
       return;
     }
 
-    var pos = triggerUnit.GetPosition();
+    var triggerUnitX = triggerUnit.X;
+    var triggerUnitY = triggerUnit.Y;
+
     for (var i = 0; i < CreateCount; i++)
     {
-      unit.Create(triggerUnit.Owner, CreateUnitTypeId, pos.X, pos.Y, triggerUnit.Facing)
+      unit.Create(triggerUnit.Owner, CreateUnitTypeId, triggerUnitX, triggerUnitY, triggerUnit.Facing)
         .SetTimedLife(Duration);
     }
 
-    EffectSystem.Add(effect.Create(SpecialEffectPath, pos.X, pos.Y), 1);
+    EffectSystem.Add(effect.Create(SpecialEffectPath, triggerUnitX, triggerUnitY), 1);
     triggerUnit.Dispose();
   }
 }

--- a/src/MacroTools/PassiveAbilities/Gate.cs
+++ b/src/MacroTools/PassiveAbilities/Gate.cs
@@ -1,5 +1,4 @@
-﻿using MacroTools.Extensions;
-using MacroTools.PassiveAbilitySystem;
+﻿using MacroTools.PassiveAbilitySystem;
 using MacroTools.Systems;
 
 namespace MacroTools.PassiveAbilities;
@@ -31,11 +30,10 @@ public sealed class Gate : PassiveAbility, IEffectOnUpgrade, IEffectOnDeath, IEf
   public void OnDeath()
   {
     var dyingGate = @event.Unit;
-    var dyingGatePos = dyingGate.GetPosition();
     var dyingGateFacing = dyingGate.Facing;
     dyingGate.Dispose();
     TurnBasedHitpointsManager.UnRegister(dyingGate);
-    var deadGate = unit.Create(@event.KillingUnit.Owner, _deadId, dyingGatePos.X, dyingGatePos.Y, dyingGateFacing);
+    var deadGate = unit.Create(@event.KillingUnit.Owner, _deadId, dyingGate.X, dyingGate.Y, dyingGateFacing);
     deadGate.SetAnimation("death");
   }
 

--- a/src/MacroTools/PassiveAbilities/PersistentSoul.cs
+++ b/src/MacroTools/PassiveAbilities/PersistentSoul.cs
@@ -46,11 +46,12 @@ public sealed class PersistentSoul : PassiveAbility, IEffectOnDeath
   public void OnDeath()
   {
     var caster = @event.Unit;
+    var casterPosition = caster.GetPosition();
 
-    foreach (var unit in GlobalGroup.EnumUnitsInRange(caster.GetPosition(), Radius)
+    foreach (var unit in GlobalGroup.EnumUnitsInRange(casterPosition, Radius)
                .Where(x => IsUnitReanimationCandidate(caster, x))
                .OrderByDescending(x => x.GetLevel())
-               .ThenBy(x => MathEx.GetDistanceBetweenPoints(caster.GetPosition(), x.GetPosition()))
+               .ThenBy(x => MathEx.GetDistanceBetweenPoints(casterPosition, x.GetPosition()))
                .Take(ReanimationCountLevel * caster.GetAbilityLevel(_abilityTypeId)))
     {
       Reanimate(caster.Owner, unit);
@@ -72,7 +73,7 @@ public sealed class PersistentSoul : PassiveAbility, IEffectOnDeath
   {
     var whichUnitPosition = whichUnit.GetPosition();
 
-    EffectSystem.Add(effect.Create(@"Abilities\Spells\Undead\AnimateDead\AnimateDeadTarget.mdl", whichUnit.X, whichUnit.Y));
+    EffectSystem.Add(effect.Create(@"Abilities\Spells\Undead\AnimateDead\AnimateDeadTarget.mdl", whichUnitPosition.X, whichUnitPosition.Y));
 
     var reanimatedUnit = unit.Create(castingPlayer, whichUnit.UnitType, whichUnitPosition.X, whichUnitPosition.Y, whichUnit.Facing);
     reanimatedUnit.RemoveAllAbilities(new List<int> { 1096905835, 1097690998, 1112498531 });

--- a/src/MacroTools/PassiveAbilities/RemoveOnDeath.cs
+++ b/src/MacroTools/PassiveAbilities/RemoveOnDeath.cs
@@ -1,5 +1,4 @@
-﻿using MacroTools.Extensions;
-using MacroTools.PassiveAbilitySystem;
+﻿using MacroTools.PassiveAbilitySystem;
 using WCSharp.Effects;
 
 namespace MacroTools.PassiveAbilities;
@@ -19,12 +18,12 @@ public sealed class RemoveOnDeath : PassiveAbility, IEffectOnDeath
   public void OnDeath()
   {
     var triggerUnit = @event.Unit;
-    var position = triggerUnit.GetPosition();
-    @event.Unit.Dispose();
 
     if (DeathEffectPath != null)
     {
-      EffectSystem.Add(effect.Create(DeathEffectPath, position.X, position.Y));
+      EffectSystem.Add(effect.Create(DeathEffectPath, triggerUnit.X, triggerUnit.Y));
     }
+
+    triggerUnit.Dispose();
   }
 }

--- a/src/MacroTools/PassiveAbilities/SummonUnitOnCast.cs
+++ b/src/MacroTools/PassiveAbilities/SummonUnitOnCast.cs
@@ -65,12 +65,11 @@ public sealed class SummonUnitOnCast : PassiveAbility, IEffectOnSpellEffect
       return;
     }
 
-    var casterPosition = triggerUnit.GetPosition();
     var summonCount = SummonCount.Base + SummonCount.PerLevel * abilityLevel;
 
     for (var i = 0; i < summonCount; i++)
     {
-      var summonedUnit = unit.Create(triggerUnit.Owner, SummonUnitTypeId, casterPosition.X, casterPosition.Y, triggerUnit.Facing);
+      var summonedUnit = unit.Create(triggerUnit.Owner, SummonUnitTypeId, triggerUnit.X, triggerUnit.Y, triggerUnit.Facing);
       summonedUnit.AddType(unittype.Summoned);
       summonedUnit.SetTimedLife(Duration);
       var summonedUnitX = summonedUnit.X;

--- a/src/MacroTools/PassiveAbilities/SummonUnitOnDeath.cs
+++ b/src/MacroTools/PassiveAbilities/SummonUnitOnDeath.cs
@@ -48,15 +48,17 @@ public sealed class SummonUnitOnDeath : PassiveAbility, IEffectOnDeath
       return;
     }
 
-    var pos = triggerUnit.GetPosition();
+    var triggerUnitX = triggerUnit.X;
+    var triggerUnitY = triggerUnit.Y;
+
     for (var i = 0; i < SummonCount; i++)
     {
-      var summonedUnit = unit.Create(triggerUnit.Owner, SummonUnitTypeId, pos.X, pos.Y, triggerUnit.Facing);
+      var summonedUnit = unit.Create(triggerUnit.Owner, SummonUnitTypeId, triggerUnitX, triggerUnitY, triggerUnit.Facing);
       summonedUnit.AddType(unittype.Summoned);
       summonedUnit.SetTimedLife(Duration);
     }
 
-    EffectSystem.Add(effect.Create(SpecialEffectPath, pos.X, pos.Y), 1);
+    EffectSystem.Add(effect.Create(SpecialEffectPath, triggerUnitX, triggerUnitY), 1);
     triggerUnit.Dispose();
   }
 }

--- a/src/MacroTools/PassiveAbilities/WarglaivesOfAzzinoth.cs
+++ b/src/MacroTools/PassiveAbilities/WarglaivesOfAzzinoth.cs
@@ -85,13 +85,15 @@ public sealed class WarglaivesOfAzzinoth : PassiveAbility, IAppliesEffectOnDamag
       }
 
       var target = @event.Unit;
+      var targetX = target.X;
+      var targetY = target.Y;
 
-      effect effect = effect.Create(Effect, target.X, target.Y);
+      effect effect = effect.Create(Effect, targetX, targetY);
       effect.Scale = EffectScale;
       effect.SetYaw(caster.Facing * MathEx.DegToRad);
       EffectSystem.Add(effect);
 
-      foreach (var nearbyUnit in GlobalGroup.EnumUnitsInRange(target.GetPosition(), Radius))
+      foreach (var nearbyUnit in GlobalGroup.EnumUnitsInRange(targetX, targetY, Radius))
       {
         if (nearbyUnit.IsAllyTo(caster.Owner) || !nearbyUnit.Alive || nearbyUnit.IsInvulnerable ||
             nearbyUnit.IsUnitType(unittype.Structure) || nearbyUnit.IsUnitType(unittype.Ancient))

--- a/src/MacroTools/Spells/DelayedMultiTargetRecall.cs
+++ b/src/MacroTools/Spells/DelayedMultiTargetRecall.cs
@@ -43,9 +43,10 @@ public sealed class DelayedMultiTargetRecall : Spell
 
   public override void OnCast(unit caster, unit target, Point targetPoint)
   {
-    var center = TargetType == SpellTargetType.None ? new Point(caster.X, caster.Y) : targetPoint;
+    var casterPosition = caster.GetPosition();
+    var center = TargetType == SpellTargetType.None ? casterPosition : targetPoint;
 
-    var distance = InstanceSystem.GetDistanceBetweenPointsEx(new Point(caster.X, caster.Y), center);
+    var distance = InstanceSystem.GetDistanceBetweenPointsEx(casterPosition, center);
     var distanceDuration = (int)distance / DistanceDivider;
     var finalDuration = distance == -1
       ? CrossDimensionalDuration

--- a/src/MacroTools/Spells/Stomp.cs
+++ b/src/MacroTools/Spells/Stomp.cs
@@ -70,10 +70,12 @@ public sealed class Stomp : Spell
   /// <inheritdoc />
   public override void OnCast(unit caster, unit target, Point targetPoint)
   {
-    EffectSystem.Add(effect.Create(SpecialEffect, caster.X, caster.Y));
+    var casterX = caster.X;
+    var casterY = caster.Y;
 
-    foreach (var enumUnit in GlobalGroup
-               .EnumUnitsInRange(new Point(caster.X, caster.Y), Radius))
+    EffectSystem.Add(effect.Create(SpecialEffect, casterX, casterY));
+
+    foreach (var enumUnit in GlobalGroup.EnumUnitsInRange(casterX, casterY, Radius))
     {
       if (!CastFilters.IsTargetEnemyAndAlive(caster, enumUnit))
       {

--- a/src/MacroTools/Utils/GlobalGroup.cs
+++ b/src/MacroTools/Utils/GlobalGroup.cs
@@ -60,4 +60,13 @@ public static class GlobalGroup
     _group.EnumUnitsInRange(point.X, point.Y, radius);
     return _group.ToList();
   }
+
+  /// <summary>
+  /// Returns a list of units within a specified radius of the given point.
+  /// </summary>
+  public static List<unit> EnumUnitsInRange(float x, float y, float radius)
+  {
+    _group.EnumUnitsInRange(x, y, radius);
+    return _group.ToList();
+  }
 }

--- a/src/WarcraftLegacies.Source/ArtifactBehaviour/EyeOfSargerasPickup.cs
+++ b/src/WarcraftLegacies.Source/ArtifactBehaviour/EyeOfSargerasPickup.cs
@@ -22,14 +22,17 @@ public static class EyeOfSargerasPickup
 
   private static void OnEyeOfSargerasPickedUp()
   {
-    if (@event.Unit.Owner == player.NeutralAggressive)
+    var triggerUnit = @event.Unit;
+    if (triggerUnit.Owner == player.NeutralAggressive)
     {
       return;
     }
 
+    var triggerUnitPosition = triggerUnit.GetPosition();
+
     var hostileNearby = GlobalGroup
-      .EnumUnitsInRange(@event.Unit.GetPosition(), 700)
-      .OrderByDescending(x => MathEx.GetDistanceBetweenPoints(x.GetPosition(), @event.Unit.GetPosition()))
+      .EnumUnitsInRange(triggerUnitPosition, 700)
+      .OrderByDescending(x => MathEx.GetDistanceBetweenPoints(x.GetPosition(), triggerUnitPosition))
       .FirstOrDefault(x => x.Owner == player.NeutralAggressive && x.Alive && !x.IsUnitType(unittype.Ancient));
     if (hostileNearby == null)
     {
@@ -38,6 +41,6 @@ public static class EyeOfSargerasPickup
       return;
     }
 
-    MissileSystem.Add(new EyeOfSargerasMissile(@event.Unit, hostileNearby, @event.ManipulatedItem));
+    MissileSystem.Add(new EyeOfSargerasMissile(triggerUnit, hostileNearby, @event.ManipulatedItem));
   }
 }

--- a/src/WarcraftLegacies.Source/PassiveAbilities/Incubate/MatureEggBuff.cs
+++ b/src/WarcraftLegacies.Source/PassiveAbilities/Incubate/MatureEggBuff.cs
@@ -34,13 +34,16 @@ public sealed class MatureEggBuff : PassiveBuff
   /// <inheritdoc />
   public override void OnDeath(bool killingBlow)
   {
+    var targetX = Target.X;
+    var targetY = Target.Y;
+
     var rallyPoint = Target.GetRallyPoint();
     if (rallyPoint.X == 0 && rallyPoint.Y == 0)
     {
-      rallyPoint = Target.GetPosition();
+      rallyPoint = new(targetX, targetY);
     }
 
-    unit.Create(Target.Owner, HatchedUnitTypeId, Target.X, Target.Y)
+    unit.Create(Target.Owner, HatchedUnitTypeId, targetX, targetY)
       .IssueOrder(ORDER_ATTACK, rallyPoint.X, rallyPoint.Y);
   }
 }

--- a/src/WarcraftLegacies.Source/Powers/ShaladrassilsBlessing.cs
+++ b/src/WarcraftLegacies.Source/Powers/ShaladrassilsBlessing.cs
@@ -4,7 +4,6 @@ using MacroTools.FactionSystem;
 using MacroTools.Setup;
 using WCSharp.Effects;
 using WCSharp.Events;
-using WCSharp.Shared.Data;
 
 namespace WarcraftLegacies.Source.Powers;
 
@@ -53,35 +52,36 @@ public sealed class ShaladrassilsBlessing : Power
 
   private void OnPlayerTakesDamage()
   {
-    var owner = @event.Unit.Owner;
-    if (!@event.Unit.IsControlPoint()
-        || _shaladrassil.Owner != owner
+    var triggerUnit = @event.Unit;
+    var triggerUnitOwner = triggerUnit.Owner;
+    if (!triggerUnit.IsControlPoint()
+        || _shaladrassil.Owner != triggerUnitOwner
         || !(_shaladrassil.Mana >= _manaCost)
-        || @event.Unit.GetLifePercent() < 100)
+        || triggerUnit.GetLifePercent() < 100)
     {
       return;
     }
 
-    if (SummonTreants(owner, @event.Unit.GetPosition()))
+    if (SummonTreants(triggerUnitOwner, triggerUnit.X, triggerUnit.Y))
     {
       _shaladrassil.Mana -= _manaCost;
     }
   }
 
-  private bool SummonTreants(player owningPlayer, Point point)
+  private bool SummonTreants(player owningPlayer, float x, float y)
   {
-    if (pathingtype.Walkability.GetPathable(point.X, point.Y))
+    if (pathingtype.Walkability.GetPathable(x, y))
     {
       return false;
     }
 
     for (var i = 0; i < _summonedUnitCount; i++)
     {
-      var treant = unit.Create(owningPlayer, _summonedUnitTypeId, point.X, point.Y);
+      var treant = unit.Create(owningPlayer, _summonedUnitTypeId, x, y);
       treant.SetTimedLife(_duration);
       treant.AddType(unittype.Summoned);
       treant.SetExploded(true);
-      EffectSystem.Add(effect.Create(@"Objects\Spawnmodels\NightElf\EntBirthTarget\EntBirthTarget.mdl", treant.GetPosition().X, treant.GetPosition().Y));
+      EffectSystem.Add(effect.Create(@"Objects\Spawnmodels\NightElf\EntBirthTarget\EntBirthTarget.mdl", treant.X, treant.Y));
     }
 
     return true;

--- a/src/WarcraftLegacies.Source/Quests/Stormwind/QuestConstructionSites.cs
+++ b/src/WarcraftLegacies.Source/Quests/Stormwind/QuestConstructionSites.cs
@@ -42,8 +42,7 @@ public sealed class QuestConstructionSites : QuestData
 
     foreach (var constructionSite in _constructionSites)
     {
-      var position = constructionSite.GetPosition();
-      completingFaction.Player.PingMinimapSimple(position.X, position.Y, 5);
+      completingFaction.Player.PingMinimapSimple(constructionSite.X, constructionSite.Y, 5);
     }
   }
 }

--- a/src/WarcraftLegacies.Source/Researches/Ahnqiraj/Progenesis.cs
+++ b/src/WarcraftLegacies.Source/Researches/Ahnqiraj/Progenesis.cs
@@ -35,15 +35,16 @@ public sealed class Progenesis : Research
 
     foreach (var worker in workers)
     {
-      var position = worker.GetPosition();
+      var workerX = worker.X;
+      var workerY = worker.Y;
       var facing = worker.Facing;
       var hitPointsPercentage = worker.GetLifePercent();
       var owner = worker.Owner;
 
-      EffectSystem.Add(effect.Create(@"Objects\Spawnmodels\Critters\Albatross\CritterBloodAlbatross.mdl", position.X, position.Y));
+      EffectSystem.Add(effect.Create(@"Objects\Spawnmodels\Critters\Albatross\CritterBloodAlbatross.mdl", workerX, workerY));
 
       worker.SafelyRemove();
-      var soldier = unit.Create(owner, TransformedUnitTypeId, position.X, position.Y, facing);
+      var soldier = unit.Create(owner, TransformedUnitTypeId, workerX, workerY, facing);
       soldier.SetLifePercent(hitPointsPercentage);
     }
   }

--- a/src/WarcraftLegacies.Source/Spells/Ascendance.cs
+++ b/src/WarcraftLegacies.Source/Spells/Ascendance.cs
@@ -27,9 +27,7 @@ public sealed class Ascendance : Spell
 
   public override void OnCast(unit caster, unit target, Point targetPoint)
   {
-    foreach (var unit in GlobalGroup
-               .EnumUnitsInRange(caster.GetPosition(), Radius)
-             )
+    foreach (var unit in GlobalGroup.EnumUnitsInRange(caster.X, caster.Y, Radius))
     {
       if (caster.Owner.IsAlly(unit.Owner))
       {

--- a/src/WarcraftLegacies.Source/Spells/BlessedGround.cs
+++ b/src/WarcraftLegacies.Source/Spells/BlessedGround.cs
@@ -66,7 +66,7 @@ public sealed class BlessedGroundSpell : Spell
 
       if (!string.IsNullOrEmpty(data.HealEffectPath))
       {
-        EffectSystem.Add(effect.Create(data.HealEffectPath, unit.GetPosition().X, unit.GetPosition().Y), 1.0f);
+        EffectSystem.Add(effect.Create(data.HealEffectPath, unit.X, unit.Y), 1.0f);
       }
     }
   }
@@ -90,7 +90,7 @@ public sealed class BlessedGroundSpell : Spell
 
       if (!string.IsNullOrEmpty(data.HealEffectPath))
       {
-        EffectSystem.Add(effect.Create(data.HealEffectPath, unit.GetPosition().X, unit.GetPosition().Y), 1.0f);
+        EffectSystem.Add(effect.Create(data.HealEffectPath, unit.X, unit.Y), 1.0f);
       }
     }
   }

--- a/src/WarcraftLegacies.Source/Spells/DeathPact.cs
+++ b/src/WarcraftLegacies.Source/Spells/DeathPact.cs
@@ -87,7 +87,7 @@ public sealed class DeathPact : Spell
 
     caster.Mana = Math.Min(currentMana + manaToRestore, maxMana);
 
-    EffectSystem.Add(effect.Create(KillEffect, targetUnit.GetPosition().X, targetUnit.GetPosition().Y));
+    EffectSystem.Add(effect.Create(KillEffect, targetUnit.X, targetUnit.Y));
   }
 
   private static bool IsValidTarget(unit target, player casterPlayer)

--- a/src/WarcraftLegacies.Source/Spells/ExactJustice/ExactJusticeChannel.cs
+++ b/src/WarcraftLegacies.Source/Spells/ExactJustice/ExactJusticeChannel.cs
@@ -103,10 +103,12 @@ public sealed class ExactJusticeChannel : Channel
   /// <inheritdoc />
   protected override void OnDispose()
   {
-    var explodeEffect = effect.Create(EffectSettings.ExplodePath, Caster.X, Caster.Y);
+    var casterX = Caster.X;
+    var casterY = Caster.Y;
+    var explodeEffect = effect.Create(EffectSettings.ExplodePath, casterX, casterY);
     explodeEffect.Scale = EffectSettings.ExplodeScale;
     EffectSystem.Add(explodeEffect);
-    foreach (var unit in GlobalGroup.EnumUnitsInRange(Caster.GetPosition(), Radius)
+    foreach (var unit in GlobalGroup.EnumUnitsInRange(casterX, casterY, Radius)
                .Where(target => CastFilters.IsTargetEnemyAndAlive(Caster, target)))
     {
       unit.TakeDamage(Caster, _damage, false, false, damageType: damagetype.Magic);

--- a/src/WarcraftLegacies.Source/Spells/HealingWavePlus/HealingWavePlus.cs
+++ b/src/WarcraftLegacies.Source/Spells/HealingWavePlus/HealingWavePlus.cs
@@ -59,9 +59,10 @@ public sealed class HealingWavePlus : Spell
 
   private unit? FindNearestAlly(unit caster, unit currentTarget, HashSet<unit> excludedUnits)
   {
-    return GlobalGroup.EnumUnitsInRange(currentTarget.GetPosition(), BounceRadius)
+    var targetPosition = currentTarget.GetPosition();
+    return GlobalGroup.EnumUnitsInRange(targetPosition, BounceRadius)
         .Where(u => HealingWavePlus.IsValidAlly(caster, u) && !excludedUnits.Contains(u))
-        .OrderBy(u => MathEx.GetDistanceBetweenPoints(currentTarget.GetPosition(), u.GetPosition()))
+        .OrderBy(u => MathEx.GetDistanceBetweenPoints(targetPosition, u.GetPosition()))
         .FirstOrDefault();
   }
 

--- a/src/WarcraftLegacies.Source/Spells/Reap/Reap.cs
+++ b/src/WarcraftLegacies.Source/Spells/Reap/Reap.cs
@@ -56,7 +56,7 @@ public sealed class Reap : Spell
         .EnumUnitsInRange(casterPosition, radius)
         .Where(x => IsValidTarget(x, caster))
         .OrderBy(x => x.Level)
-        .ThenBy(x => MathEx.GetDistanceBetweenPoints(caster.GetPosition(), x.GetPosition()))
+        .ThenBy(x => MathEx.GetDistanceBetweenPoints(casterPosition, x.GetPosition()))
         .Take(unitsSlain)
         .ToList();
 

--- a/src/WarcraftLegacies.Source/Spells/RendSoul.cs
+++ b/src/WarcraftLegacies.Source/Spells/RendSoul.cs
@@ -38,13 +38,12 @@ public sealed class RendSoul : Spell
     EffectSystem.Add(effect.Create(EffectCaster, caster.X, caster.Y));
     EffectSystem.Add(effect.Create(EffectTarget, target.X, target.Y));
 
-    var targetPosition = target.GetPosition();
     target.Kill();
 
     caster.Heal(healthGained);
     caster.Mana += manaGained;
 
-    var summonedUnit = unit.Create(caster.Owner, UnitTypeSummoned, targetPosition.X, targetPosition.Y, caster.Facing);
+    var summonedUnit = unit.Create(caster.Owner, UnitTypeSummoned, target.X, target.Y, caster.Facing);
     summonedUnit.SetTimedLife(Duration);
     summonedUnit.AddType(unittype.Summoned);
   }

--- a/src/WarcraftLegacies.Source/Spells/ResoluteHeart.cs
+++ b/src/WarcraftLegacies.Source/Spells/ResoluteHeart.cs
@@ -45,13 +45,14 @@ public sealed class ResoluteHeart : PassiveAbility, IAppliesEffectOnDamage
     var caster = @event.DamageSource;
     var damagedUnit = @event.DamageTarget;
 
-
     if (!@event.IsAttack || caster.GetAbilityLevel(AbilityTypeId) == 0 || damagedUnit == null)
     {
       return;
     }
 
-    if (!damagedUnit.IsEnemyTo(caster.Owner) || damagedUnit.IsUnitType(unittype.Structure) ||
+    var owner = caster.Owner;
+
+    if (!damagedUnit.IsEnemyTo(owner) || damagedUnit.IsUnitType(unittype.Structure) ||
         damagedUnit.IsUnitType(unittype.Ancient))
     {
       return;
@@ -69,16 +70,16 @@ public sealed class ResoluteHeart : PassiveAbility, IAppliesEffectOnDamage
     var healAmount = damageDealt * 0.2f;
 
     // Heal nearby allies
-    foreach (var nearbyUnit in GlobalGroup.EnumUnitsInRange(caster.GetPosition(), Radius))
+    foreach (var nearbyUnit in GlobalGroup.EnumUnitsInRange(caster.X, caster.Y, Radius))
     {
-      if (nearbyUnit == caster || !nearbyUnit.IsAllyTo(caster.Owner) || !nearbyUnit.Alive)
+      if (nearbyUnit == caster || !nearbyUnit.IsAllyTo(owner) || !nearbyUnit.Alive)
       {
         continue;
       }
 
       if (!string.IsNullOrEmpty(EffectPath))
       {
-        effect.Create(EffectPath, nearbyUnit.GetPosition().X, nearbyUnit.GetPosition().Y);
+        effect.Create(EffectPath, nearbyUnit.X, nearbyUnit.Y);
       }
 
       nearbyUnit.Heal(healAmount);

--- a/src/WarcraftLegacies.Source/Spells/Slipstream/SlipstreamPortalBuff.cs
+++ b/src/WarcraftLegacies.Source/Spells/Slipstream/SlipstreamPortalBuff.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using MacroTools.Extensions;
 using WCSharp.Buffs;
 using WCSharp.Effects;
 
@@ -39,7 +38,7 @@ public sealed class SlipstreamPortalBuff : PassiveBuff
     }
 
     _state = SlipstreamPortalState.Opening;
-    _progressBar = effect.Create(@"war3mapImported\Progressbar10sec.mdx", Target.GetPosition().X, Target.GetPosition().Y);
+    _progressBar = effect.Create(@"war3mapImported\Progressbar10sec.mdx", Target.X, Target.Y);
     _progressBar.SetTimeScale(10f / delay);
     _progressBar.SetColor(Caster.Owner);
     _progressBar.SetHeight(450);

--- a/src/WarcraftLegacies.Source/Spells/Slipstream/SlipstreamSpell.cs
+++ b/src/WarcraftLegacies.Source/Spells/Slipstream/SlipstreamSpell.cs
@@ -1,7 +1,5 @@
 ﻿using MacroTools.ChannelSystem;
 using MacroTools.Data;
-using MacroTools.Extensions;
-using MacroTools.Instances;
 using MacroTools.SpellSystem;
 using WCSharp.Shared;
 using WCSharp.Shared.Data;
@@ -64,10 +62,7 @@ public sealed class SlipstreamSpell : Spell
   /// <inheritdoc/>
   public override void OnStartCast(unit caster, unit target, Point targetPoint)
   {
-    if (!pathingtype.Walkability.GetPathable(targetPoint.X, targetPoint.Y) &&
-        !(Util.DistanceBetweenPoints(caster.X, caster.Y, targetPoint.X,
-          targetPoint.Y) < 500) && InstanceSystem.GetPointInstance(caster.GetPosition()) ==
-        InstanceSystem.GetPointInstance(targetPoint))
+    if (!SlipstreamSpellHelper.IsPointValidTarget(caster, targetPoint))
     {
       return;
     }

--- a/src/WarcraftLegacies.Source/Spells/Slipstream/SlipstreamSpellHelper.cs
+++ b/src/WarcraftLegacies.Source/Spells/Slipstream/SlipstreamSpellHelper.cs
@@ -1,0 +1,24 @@
+﻿using MacroTools.Extensions;
+using MacroTools.Instances;
+using WCSharp.Shared;
+using WCSharp.Shared.Data;
+
+namespace WarcraftLegacies.Source.Spells.Slipstream;
+
+internal static class SlipstreamSpellHelper
+{
+  public static bool IsPointValidTarget(unit caster, Point targetPoint)
+  {
+    return IsPointValidTarget(caster, targetPoint, targetPoint);
+  }
+
+  public static bool IsPointValidTarget(unit caster, Point targetPoint, Point targetLocation)
+  {
+    var casterPosition = caster.GetPosition();
+    var isPathable = pathingtype.Walkability.GetPathable(targetPoint.X, targetPoint.Y);
+    var isWithinRange = Util.DistanceBetweenPoints(casterPosition.X, casterPosition.Y, targetLocation.X, targetLocation.Y) < 500;
+    var isSameInstance = InstanceSystem.GetPointInstance(casterPosition) == InstanceSystem.GetPointInstance(targetPoint);
+
+    return !isPathable && !isWithinRange && isSameInstance;
+  }
+}

--- a/src/WarcraftLegacies.Source/Spells/Slipstream/SlipstreamSpellSpecificDestination.cs
+++ b/src/WarcraftLegacies.Source/Spells/Slipstream/SlipstreamSpellSpecificDestination.cs
@@ -1,9 +1,6 @@
 ﻿using MacroTools.ChannelSystem;
 using MacroTools.Data;
-using MacroTools.Extensions;
-using MacroTools.Instances;
 using MacroTools.SpellSystem;
-using WCSharp.Shared;
 using WCSharp.Shared.Data;
 
 namespace WarcraftLegacies.Source.Spells.Slipstream;
@@ -49,7 +46,7 @@ public sealed class SlipstreamSpellSpecificDestination : Spell
   /// <inheritdoc/>
   public override void OnCast(unit caster, unit target, Point targetPoint)
   {
-    if (!IsPointValidTarget(caster, targetPoint))
+    if (!SlipstreamSpellHelper.IsPointValidTarget(caster, targetPoint, TargetLocation))
     {
       return;
     }
@@ -69,7 +66,7 @@ public sealed class SlipstreamSpellSpecificDestination : Spell
   /// <inheritdoc/>
   public override void OnStartCast(unit caster, unit target, Point targetPoint)
   {
-    if (IsPointValidTarget(caster, targetPoint))
+    if (SlipstreamSpellHelper.IsPointValidTarget(caster, targetPoint, TargetLocation))
     {
       return;
     }
@@ -83,9 +80,4 @@ public sealed class SlipstreamSpellSpecificDestination : Spell
     whichUnit.Mana += whichUnit.GetAbilityManaCost(Id, GetAbilityLevel(whichUnit));
     whichUnit.EndAbilityCooldown(Id);
   }
-
-  private bool IsPointValidTarget(unit caster, Point targetPoint) =>
-    !pathingtype.Walkability.GetPathable(targetPoint.X, targetPoint.Y)
-    && !(Util.DistanceBetweenPoints(caster.X, caster.Y, TargetLocation.X, TargetLocation.Y) < 500)
-    && InstanceSystem.GetPointInstance(caster.GetPosition()) == InstanceSystem.GetPointInstance(targetPoint);
 }


### PR DESCRIPTION
There are still many left, but this removes some of the low hanging fruit around `UnitExtensions.GetPosition`