### PR TITLE
refactor: expose `PlayerData`, drop extensions mirroring properties

### DIFF
--- a/src/MacroTools/ArtifactSystem/Artifact.cs
+++ b/src/MacroTools/ArtifactSystem/Artifact.cs
@@ -179,7 +179,13 @@ public sealed class Artifact
 
   private void OnPlayerFactionChange(object? sender, PlayerFactionChangeEventArgs e)
   {
-    if (OwningPlayer?.GetFaction() == e.Player.GetFaction())
+    var owningFaction = OwningPlayer?.GetPlayerData().Faction;
+    if (owningFaction == null)
+    {
+      return;
+    }
+
+    if (owningFaction == e.Player.GetPlayerData().Faction)
     {
       FactionChanged?.Invoke(this, this);
     }

--- a/src/MacroTools/BookSystem/ArtifactSystem/ArtifactCard.cs
+++ b/src/MacroTools/BookSystem/ArtifactSystem/ArtifactCard.cs
@@ -113,11 +113,12 @@ public sealed class ArtifactCard : Card<Artifact>
     switch (_artifact!.LocationType)
     {
       case ArtifactLocationType.Unit:
-        if (_artifact.OwningPlayer?.GetFaction() != null)
+        var owningFaction = _artifact.OwningPlayer?.GetPlayerData().Faction;
+        if (owningFaction != null)
         {
           _text.Visible = true;
           _pingButton.Visible = false;
-          _text.Text = $"Owned by {_artifact.OwningPlayer?.GetFaction()?.ColoredName}";
+          _text.Text = $"Owned by {owningFaction.ColoredName}";
         }
         else
         {
@@ -162,7 +163,7 @@ public sealed class ArtifactCard : Card<Artifact>
   {
     try
     {
-      if (e == _artifact?.OwningPlayer?.GetFaction())
+      if (e == _artifact?.OwningPlayer?.GetPlayerData().Faction)
       {
         RefreshLocationDescriptionFrame();
       }

--- a/src/MacroTools/BookSystem/Powers/PowerBook.cs
+++ b/src/MacroTools/BookSystem/Powers/PowerBook.cs
@@ -19,17 +19,19 @@ public sealed class PowerBook : Book<Power, PowerPage, PowerCard, PowerPageFacto
   {
   }
 
-  public static PowerBook Create(player trackedPlayer)
+  public static PowerBook Create(player whichPlayer)
   {
+    var playerData = whichPlayer.GetPlayerData();
+
     var book = new PowerBook
     {
       Title = "Powers",
       LauncherParent = framehandle.Get("UpperButtonBarMenuButton", 0),
       Position = new Point(0.36f, 0.35f),
-      TrackedFaction = trackedPlayer.GetFaction()
+      TrackedFaction = playerData.Faction
     };
 
-    trackedPlayer.GetPlayerData().ChangedFaction += book.OnPlayerChangedFaction;
+    playerData.ChangedFaction += book.OnPlayerChangedFaction;
 
     return book;
   }
@@ -71,7 +73,7 @@ public sealed class PowerBook : Book<Power, PowerPage, PowerCard, PowerPageFacto
 
   private void OnPlayerChangedFaction(object? sender, PlayerFactionChangeEventArgs args)
   {
-    TrackedFaction = args.Player.GetFaction();
+    TrackedFaction = args.Player.GetPlayerData().Faction;
   }
 
   private void OnFactionRemovePower(object? sender, FactionPowerEventArgs factionPowerEventArgs)

--- a/src/MacroTools/Buffs/IncomeBuff.cs
+++ b/src/MacroTools/Buffs/IncomeBuff.cs
@@ -23,11 +23,11 @@ public sealed class IncomeBuff : PassiveBuff
 
   public override void OnApply()
   {
-    CastingPlayer.AddBonusIncome(_bonusIncome);
+    CastingPlayer.GetPlayerData().BonusIncome += _bonusIncome;
   }
 
   public override void OnDispose()
   {
-    CastingPlayer.AddBonusIncome(-_bonusIncome);
+    CastingPlayer.GetPlayerData().BonusIncome -= _bonusIncome;
   }
 }

--- a/src/MacroTools/Cheats/CheatPingGoldMines.cs
+++ b/src/MacroTools/Cheats/CheatPingGoldMines.cs
@@ -20,7 +20,7 @@ public sealed class CheatPingGoldMines : Command
   /// <inheritdoc />
   public override string Execute(player commandUser, params string[] parameters)
   {
-    var faction = commandUser.GetFaction();
+    var faction = commandUser.GetPlayerData().Faction;
     if (faction == null)
     {
       return "You don't have a Faction.";

--- a/src/MacroTools/Cheats/CheatQuestProgress.cs
+++ b/src/MacroTools/Cheats/CheatQuestProgress.cs
@@ -40,7 +40,7 @@ public sealed class CheatQuestProgress : Command
     Faction? faction;
     if (parameters.Length < 2)
     {
-      faction = cheater.GetFaction();
+      faction = cheater.GetPlayerData().Faction;
       if (faction == null)
       {
         return $"You are not playing as a {nameof(Faction)}, so you don't have any quests.";

--- a/src/MacroTools/Cheats/CheatRemovePower.cs
+++ b/src/MacroTools/Cheats/CheatRemovePower.cs
@@ -20,7 +20,7 @@ public sealed class CheatRemovePower : Command
   /// <inheritdoc />
   public override string Execute(player commandUser, params string[] parameters)
   {
-    var faction = commandUser.GetFaction();
+    var faction = commandUser.GetPlayerData().Faction;
     if (faction == null)
     {
       return "You have no faction so you can't have powers.";

--- a/src/MacroTools/Cheats/CheatSetResearchLevel.cs
+++ b/src/MacroTools/Cheats/CheatSetResearchLevel.cs
@@ -39,7 +39,7 @@ public sealed class CheatSetResearchLevel : Command
       return "You must specify a valid research level as the second parameter.";
     }
 
-    var faction = cheater.GetFaction();
+    var faction = cheater.GetPlayerData().Faction;
     if (faction == null)
     {
       return $"You need to have a valid {nameof(Faction)} to use this Command.";

--- a/src/MacroTools/Cheats/CheatTeam.cs
+++ b/src/MacroTools/Cheats/CheatTeam.cs
@@ -22,14 +22,15 @@ public sealed class CheatTeam : Command
   public override string Description => "Sets the specified faction to the specified team.";
 
   /// <inheritdoc />
-  public override string Execute(player cheater, params string[] parameters)
+  public override string Execute(player _, params string[] parameters)
   {
     if (!FactionManager.TryGetFactionByName(parameters[0], out var faction))
     {
       return $"There is no faction named {parameters[0]}.";
     }
 
-    if (faction.Player == null)
+    var player = faction.Player;
+    if (player == null)
     {
       return $"The specified {nameof(Faction)} is not occupied by a player and therefore cannot have a {nameof(Team)}.";
     }
@@ -39,7 +40,8 @@ public sealed class CheatTeam : Command
       return $"You must specify a valid {nameof(Team)} name as the second parameter.";
     }
 
-    faction.Player.SetTeam(team);
+    player.GetPlayerData().SetTeam(team);
+
     return $"Set {faction.Name}'s {nameof(Team)} to {team.Name}.";
   }
 }

--- a/src/MacroTools/Commands/GiveGold.cs
+++ b/src/MacroTools/Commands/GiveGold.cs
@@ -37,8 +37,8 @@ public sealed class GiveGold : Command
       return $"There is nobody playing the {targetFaction.Name} faction.";
     }
 
-    var cheaterTeam = cheater.GetTeam();
-    if (cheaterTeam != targetFaction.Player.GetTeam())
+    var cheaterTeam = cheater.GetPlayerData().Team;
+    if (cheaterTeam != targetFaction.Player.GetPlayerData().Team)
     {
       return $"{targetFaction.Name} isn't on your team, so you can't give them gold.";
     }

--- a/src/MacroTools/Commands/Limited.cs
+++ b/src/MacroTools/Commands/Limited.cs
@@ -33,7 +33,7 @@ public sealed class Limited : Command
 
     var limitedUnits = GlobalGroup
       .EnumUnitsOfPlayer(commandUser)
-      .Where(u => commandUser.GetObjectLimit(u.UnitType) is > 0 and < Faction.Unlimited && u.Alive);
+      .Where(u => commandUser.GetPlayerData().GetObjectLimit(u.UnitType) is > 0 and < Faction.Unlimited && u.Alive);
 
     foreach (var unit in limitedUnits)
     {

--- a/src/MacroTools/Commands/Observer.cs
+++ b/src/MacroTools/Commands/Observer.cs
@@ -34,15 +34,14 @@ public sealed class Observer : Command
   /// <inheritdoc />
   public override string Execute(player commandUser, params string[] parameters)
   {
-    var triggerFaction = @event.Player.GetFaction();
-    if (triggerFaction == null)
+    var playerData = commandUser.GetPlayerData();
+    if (playerData.Faction == null)
     {
-      throw new InvalidOperationException(
-        $"{@event.Player.Name} tried to execute {nameof(Observer)}, but they don't have a {nameof(Faction)}.");
+      throw new InvalidOperationException($"{commandUser.Name} tried to execute {nameof(Observer)}, but they don't have a {nameof(Faction)}.");
     }
 
-    triggerFaction.Defeat();
-    triggerFaction.Player?.SetTeam(_observers!);
+    playerData.Faction.Defeat();
+    playerData.SetTeam(_observers!);
 
     return "You have become an observer.";
   }

--- a/src/MacroTools/Commands/Share.cs
+++ b/src/MacroTools/Commands/Share.cs
@@ -22,7 +22,7 @@ public sealed class Share : Command
   /// <inheritdoc />
   public override string Execute(player cheater, params string[] parameters)
   {
-    var cheaterTeam = cheater.GetTeam();
+    var cheaterTeam = cheater.GetPlayerData().Team;
 
     if (parameters.Length >= 1 && parameters[0].ToLower() == "all")
     {
@@ -30,7 +30,7 @@ public sealed class Share : Command
 
       foreach (var faction in factions)
       {
-        if (faction.Player != null && faction.Player.GetTeam() == cheaterTeam)
+        if (faction.Player != null && faction.Player.GetPlayerData().Team == cheaterTeam)
         {
           cheater.SetAlliance(faction.Player, alliancetype.SharedControl, true);
         }
@@ -49,7 +49,7 @@ public sealed class Share : Command
       return $"There is nobody playing the {targetFaction.Name} faction.";
     }
 
-    if (cheaterTeam != targetFaction.Player.GetTeam())
+    if (cheaterTeam != targetFaction.Player.GetPlayerData().Team)
     {
       return $"{targetFaction.Name} isn't on your team, so you can't share control with them.";
     }

--- a/src/MacroTools/ControlPointSystem/ControlPointManager.cs
+++ b/src/MacroTools/ControlPointSystem/ControlPointManager.cs
@@ -23,9 +23,9 @@ public sealed class ControlPointManager
       {
         foreach (var player in Util.EnumeratePlayers(playerslotstate.Playing, mapcontrol.User))
         {
-          if (player.GetFaction() != null)
+          var playerData = player.GetPlayerData();
+          if (playerData.Faction != null)
           {
-            var playerData = player.GetPlayerData();
             playerData.AddFractionalGold(playerData.TotalIncome * Period / 60);
           }
         }
@@ -180,9 +180,9 @@ public sealed class ControlPointManager
 
   private static void RegisterIncome(ControlPoint controlPoint)
   {
-    var controlPointOwner = PlayerData.ByHandle(controlPoint.Owner);
-    controlPointOwner.AddControlPoint(controlPoint);
-    controlPointOwner.BaseIncome = controlPoint.Owner.GetBaseIncome() + controlPoint.Value;
+    var playerData = controlPoint.Owner.GetPlayerData();
+    playerData.AddControlPoint(controlPoint);
+    playerData.BaseIncome += controlPoint.Value;
   }
 
   private static void RegisterDamageTrigger(ControlPoint controlPoint)
@@ -316,9 +316,11 @@ public sealed class ControlPointManager
   {
     var flooredLevel = (int)controlPoint.ControlLevel;
 
-    var defenderUnitTypeId = controlPoint.Owner.GetFaction()?.ControlPointDefenderUnitTypeId ??
-                             ControlLevelSettings.DefaultDefenderUnitTypeId;
-    controlPoint.Defender ??= unit.Create(controlPoint.Owner, defenderUnitTypeId, controlPoint.Unit.X, controlPoint.Unit.Y);
+    var owner = controlPoint.Owner;
+    var playerData = owner.GetPlayerData();
+
+    var defenderUnitTypeId = playerData.Faction?.ControlPointDefenderUnitTypeId ?? ControlLevelSettings.DefaultDefenderUnitTypeId;
+    controlPoint.Defender ??= unit.Create(owner, defenderUnitTypeId, controlPoint.Unit.X, controlPoint.Unit.Y);
     controlPoint.Defender.AddAbility(FourCC("Aloc"));
     controlPoint.Defender.IsInvulnerable = true;
     ConfigureControlPointOrDefenderAttack(controlPoint.Defender, flooredLevel);

--- a/src/MacroTools/Extensions/PlayerData.cs
+++ b/src/MacroTools/Extensions/PlayerData.cs
@@ -10,7 +10,7 @@ namespace MacroTools.Extensions;
 /// <summary>
 /// Provides extra information about players that is not already tracked by the Warcraft 3 engine.
 /// </summary>
-internal sealed class PlayerData
+public sealed class PlayerData
 {
   private static readonly Dictionary<int, PlayerData> _byId = new();
 
@@ -278,7 +278,7 @@ internal sealed class PlayerData
 
   public void SetObjectLevel(int obj, int level)
   {
-    var objectLimit = _player.GetObjectLimit(obj);
+    var objectLimit = GetObjectLimit(obj);
 
     if (level > objectLimit)
     {

--- a/src/MacroTools/Extensions/PlayerExtensions.cs
+++ b/src/MacroTools/Extensions/PlayerExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using MacroTools.ControlPointSystem;
 using MacroTools.DialogueSystem;
-using MacroTools.FactionSystem;
 using MacroTools.Save;
 using MacroTools.Utils;
 using WCSharp.Shared.Data;
@@ -48,46 +47,6 @@ public static class PlayerExtensions
   }
 
   /// <summary>
-  /// Returns the maximum number of units the player can build of the given type, or the maximum research level
-  /// the player can achieve for the given type.
-  /// </summary>
-  /// <param name="player">The player in question.</param>
-  /// <param name="objectId">The unit type ID or research ID we want to know about.</param>
-  public static int GetObjectLimit(this player player, int objectId) =>
-    PlayerData.ByHandle(player).GetObjectLimit(objectId);
-
-  /// <summary>Returns the number of <see cref="ControlPoint"/>s a player controls.</summary>
-  public static int GetControlPointCount(this player player) => PlayerData.ByHandle(player).ControlPoints.Count;
-
-  /// <summary>Returns the number of <see cref="ControlPoint"/>s a player controls.</summary>
-  public static List<ControlPoint> GetControlPoints(this player player) => PlayerData.ByHandle(player).ControlPoints;
-
-  /// <summary>Returns the player's <see cref="Team"/>.</summary>
-  public static Team? GetTeam(this player player) => PlayerData.ByHandle(player).Team;
-
-  /// <summary>Sets the player's <see cref="Team"/>.</summary>
-  public static void SetTeam(this player player, Team? whichTeam) => PlayerData.ByHandle(player).SetTeam(whichTeam);
-
-  /// <summary>Returns the player's <see cref="Faction"/>.</summary>
-  public static Faction? GetFaction(this player player) => PlayerData.ByHandle(player).Faction;
-
-  /// <summary>Sets the player's <see cref="Faction"/>.</summary>
-  public static void SetFaction(this player player, Faction faction) => PlayerData.ByHandle(player).Faction = faction;
-
-  /// <summary>Returns the player's gold income, including any bonuses.</summary>
-  public static int GetTotalIncome(this player player) => PlayerData.ByHandle(player).TotalIncome;
-
-  /// <summary>Returns the player's bonus gold income.</summary>
-  public static int GetBonusIncome(this player player) => PlayerData.ByHandle(player).BonusIncome;
-
-  /// <summary>Returns the player's gold income, without any bonuses.</summary>
-  public static int GetBaseIncome(this player player) => PlayerData.ByHandle(player).BaseIncome;
-
-  /// <summary>Modifies the player's bonus income.</summary>
-  public static void AddBonusIncome(this player player, int value) =>
-    PlayerData.ByHandle(player).BonusIncome += value;
-
-  /// <summary>
   /// Rescues all <paramref name="units"/> for <paramref name="newOwningPlayer"/>.
   /// </summary>
   /// <param name="newOwningPlayer">The player who should own the units after being rescued</param>
@@ -102,15 +61,6 @@ public static class PlayerExtensions
     }
   }
 
-  internal static void SetObjectLevel(this player player, int objectId, int level) =>
-    PlayerData.ByHandle(player).SetObjectLevel(objectId, level);
-
-  internal static void ModObjectLimit(this player player, int objectId, int limit) =>
-    PlayerData.ByHandle(player).ModObjectLimit(objectId, limit);
-
-  internal static void SetObjectLimit(this player player, int objectId, int limit) =>
-    PlayerData.ByHandle(player).SetObjectLimit(objectId, limit);
-
   internal static void SetColorAndChangeExisting(this player whichPlayer, playercolor color)
   {
     whichPlayer.Color = color;
@@ -120,8 +70,7 @@ public static class PlayerExtensions
     }
   }
 
-  internal static PlayerData GetPlayerData(this player player) =>
-    PlayerData.ByHandle(player);
+  public static PlayerData GetPlayerData(this player player) => PlayerData.ByHandle(player);
 
   /// <summary>
   /// Safely removes all of the player's units.

--- a/src/MacroTools/FactionChoices/FactionChoiceDialogPresenter.cs
+++ b/src/MacroTools/FactionChoices/FactionChoiceDialogPresenter.cs
@@ -26,9 +26,8 @@ public sealed class FactionChoiceDialogPresenter : ChoiceDialogPresenter<Faction
     var pickedFaction = choice.Faction;
     ReplaceStartingUnitsWithFactionEquivalents(pickingPlayer, choice, pickedFaction);
 
-    pickingPlayer
-      .RepositionCamera(choice.StartingArea.Center)
-      .SetFaction(pickedFaction);
+    pickingPlayer.RepositionCamera(choice.StartingArea.Center);
+    pickingPlayer.GetPlayerData().Faction = pickedFaction;
 
     FactionManager.Register(pickedFaction);
     CleanupUnpickedFactions(choice);

--- a/src/MacroTools/FactionSystem/FactionManager.cs
+++ b/src/MacroTools/FactionSystem/FactionManager.cs
@@ -58,7 +58,8 @@ public static class FactionManager
     {
       try
       {
-        var faction = @event.Player.GetFaction();
+        var triggerPlayer = @event.Player;
+        var faction = triggerPlayer.GetPlayerData().Faction;
         if (faction == null)
         {
           return;
@@ -68,13 +69,13 @@ public static class FactionManager
         var research = ResearchManager.GetFromTypeId(researchId);
         if (research == null || !research.IncompatibleWith.Any(x => faction.GetObjectLevel(x.ResearchTypeId) > 0))
         {
-          faction.SetObjectLevel(researchId, @event.Player.GetTechResearched(researchId));
+          faction.SetObjectLevel(researchId, triggerPlayer.GetTechResearched(researchId));
           if (research == null)
           {
             return;
           }
 
-          research.OnResearch(@event.Player);
+          research.OnResearch(triggerPlayer);
           foreach (var otherResearch in research.IncompatibleWith)
           {
             faction.SetObjectLimit(otherResearch.ResearchTypeId, -Faction.Unlimited);
@@ -83,7 +84,7 @@ public static class FactionManager
         else
         {
           faction.SetObjectLimit(researchId, -Faction.Unlimited);
-          research.Refund(@event.Player);
+          research.Refund(triggerPlayer);
         }
       }
       catch (Exception ex)

--- a/src/MacroTools/FactionSystem/Team.cs
+++ b/src/MacroTools/FactionSystem/Team.cs
@@ -27,7 +27,7 @@ public sealed class Team
   /// <summary>
   /// The number of players in the <see cref="Team"/> who have not been defeated.
   /// </summary>
-  public int UndefeatedPlayerCount => _members.Count(x => x.GetFaction()?.ScoreStatus != ScoreStatus.Defeated);
+  public int UndefeatedPlayerCount => _members.Count(x => x.GetPlayerData().Faction?.ScoreStatus != ScoreStatus.Defeated);
 
   /// <summary>
   ///   Music that plays when this <see cref="Team" /> wins the game.
@@ -62,7 +62,7 @@ public sealed class Team
   {
     foreach (var member in _members)
     {
-      var memberFaction = member.GetFaction();
+      var memberFaction = member.GetPlayerData().Faction;
       if (memberFaction != null)
       {
         yield return memberFaction;
@@ -128,14 +128,14 @@ public sealed class Team
       return;
     }
 
-    var faction = whichPlayer.GetFaction();
+    var faction = whichPlayer.GetPlayerData().Faction;
     if (faction == null)
     {
       return;
     }
 
     DisplayText($"{faction.ColoredName}|r is no longer invited to join the {Name}.");
-    faction.Player.DisplayTextTo($"You are no longer invited to join the {Name}.");
+    whichPlayer.DisplayTextTo($"You are no longer invited to join the {Name}.");
     _invitees.Remove(whichPlayer);
   }
 
@@ -149,15 +149,14 @@ public sealed class Team
       return;
     }
 
-    var faction = whichPlayer.GetFaction();
-
+    var faction = whichPlayer.GetPlayerData().Faction;
     if (faction == null)
     {
       return;
     }
 
     DisplayText($"{faction.ColoredName}|r has been invited to join the {Name}.");
-    faction.Player.DisplayTextTo($"You have been invited to join the {Name}. Type -join {Name} to accept.");
+    whichPlayer.DisplayTextTo($"You have been invited to join the {Name}. Type -join {Name} to accept.");
     _invitees.Add(whichPlayer);
   }
 
@@ -193,7 +192,7 @@ public sealed class Team
   {
     foreach (var player in _members)
     {
-      if (player.GetFaction()!.HasEssentialLegend)
+      if (player.GetPlayerData().Faction!.HasEssentialLegend)
       {
         return true;
       }
@@ -209,8 +208,8 @@ public sealed class Team
     {
       case TeamSharedVisionMode.TraditionalAlliesOnly:
         {
-          var joiningPlayerTradTeam = playerA.GetFaction()?.TraditionalTeam;
-          var existingPlayerTradTeam = playerB.GetFaction()?.TraditionalTeam;
+          var joiningPlayerTradTeam = playerA.GetPlayerData().Faction?.TraditionalTeam;
+          var existingPlayerTradTeam = playerB.GetPlayerData().Faction?.TraditionalTeam;
           allianceState = joiningPlayerTradTeam == existingPlayerTradTeam ? AllianceState.AlliedVision : AllianceState.Allied;
           break;
         }

--- a/src/MacroTools/ObjectiveSystem/Objective.cs
+++ b/src/MacroTools/ObjectiveSystem/Objective.cs
@@ -98,7 +98,7 @@ public abstract class Objective
   /// </summary>
   protected bool IsPlayerOnSameTeamAsAnyEligibleFaction(player whichPlayer)
   {
-    var playerTeam = whichPlayer.GetTeam();
+    var playerTeam = whichPlayer.GetPlayerData().Team;
     if (playerTeam == null)
     {
       return false;
@@ -106,7 +106,7 @@ public abstract class Objective
 
     foreach (var eligibleFaction in EligibleFactions)
     {
-      if (eligibleFaction.Player != null && eligibleFaction.Player.GetTeam() == playerTeam)
+      if (eligibleFaction.Player != null && eligibleFaction.Player.GetPlayerData().Team == playerTeam)
       {
         return true;
       }

--- a/src/MacroTools/ObjectiveSystem/Objectives/ArtifactBased/ObjectiveNoOtherPlayerGetsArtifact.cs
+++ b/src/MacroTools/ObjectiveSystem/Objectives/ArtifactBased/ObjectiveNoOtherPlayerGetsArtifact.cs
@@ -34,6 +34,6 @@ public sealed class ObjectiveNoOtherPlayerGetsArtifact : Objective
 
   private void RefreshProgress(Faction whichFaction)
   {
-    Progress = _target.OwningPlayer?.GetFaction() == whichFaction ? QuestProgress.Complete : QuestProgress.Failed;
+    Progress = _target.OwningPlayer?.GetPlayerData().Faction == whichFaction ? QuestProgress.Complete : QuestProgress.Failed;
   }
 }

--- a/src/MacroTools/QuestSystem/FactionQuestExtensions.cs
+++ b/src/MacroTools/QuestSystem/FactionQuestExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using MacroTools.Extensions;
 using MacroTools.FactionSystem;
 using MacroTools.Sound;
+using WCSharp.Shared;
 
 namespace MacroTools.QuestSystem;
 
@@ -11,20 +12,26 @@ public static class FactionQuestExtensions
   /// </summary>
   internal static void DisplayCompletedGlobal(this player whichPlayer, QuestData questData)
   {
-    var soundCompleted = SoundLibrary.Completed;
-    var soundFailed = SoundLibrary.Failed;
-    (player.LocalPlayer.GetTeam()?.Contains(whichPlayer) == true
-       ? soundCompleted
-       : soundFailed).Start();
+    var whichplayerData = whichPlayer.GetPlayerData();
+    var localPlayerData = player.LocalPlayer.GetPlayerData();
+    var localPlayerIsAlly = localPlayerData.Team?.Contains(whichPlayer) == true;
 
-    foreach (var enumPlayer in WCSharp.Shared.Util.EnumeratePlayers())
+    var sound = localPlayerIsAlly ? SoundLibrary.Completed : SoundLibrary.Failed;
+    sound.Start();
+
+    var message = $"\n|cffffcc00MAJOR EVENT - {whichplayerData.Faction?.PrefixCol}{questData.Title}|r\n{questData.RewardFlavour}\n";
+
+    foreach (var recipient in Util.EnumeratePlayers(playerslotstate.Playing, mapcontrol.User))
     {
-      if (enumPlayer != whichPlayer)
+      if (recipient == whichPlayer)
       {
-        if (PlayerData.ByHandle(whichPlayer).PlayerSettings.ShowQuestText)
-        {
-          enumPlayer.DisplayTextTo($"\n|cffffcc00MAJOR EVENT - {whichPlayer.GetFaction()?.PrefixCol}{questData.Title}|r\n{questData.RewardFlavour}\n");
-        }
+        continue;
+      }
+
+      var recipientData = recipient.GetPlayerData();
+      if (recipientData.PlayerSettings.ShowQuestText)
+      {
+        recipient.DisplayTextTo(message);
       }
     }
   }

--- a/src/MacroTools/ResearchSystems/ParentChildResearchSystem.cs
+++ b/src/MacroTools/ResearchSystems/ParentChildResearchSystem.cs
@@ -16,7 +16,7 @@ public static class ParentChildResearchSystem
   {
     PlayerUnitEvents.Register(ResearchEvent.IsFinished, () =>
     {
-      var triggerFaction = @event.Player.GetFaction();
+      var triggerFaction = @event.Player.GetPlayerData().Faction;
       triggerFaction?.ModObjectLimit(childResearch, 1);
       triggerFaction?.SetObjectLevel(childResearch, triggerFaction.GetObjectLevel(parentResearch));
     }, parentResearch);

--- a/src/MacroTools/ResearchSystems/Research.cs
+++ b/src/MacroTools/ResearchSystems/Research.cs
@@ -56,7 +56,8 @@ public abstract class Research
     researchingPlayer.Gold += GoldCost;
     if (unresearch)
     {
-      researchingPlayer.SetObjectLevel(ResearchTypeId, Math.Min(0, researchingPlayer.GetObjectLimit(ResearchTypeId)));
+      var playerData = researchingPlayer.GetPlayerData();
+      playerData.SetObjectLevel(ResearchTypeId, Math.Min(0, playerData.GetObjectLimit(ResearchTypeId)));
     }
   }
 }

--- a/src/MacroTools/Setup/CustomPlayerUnitEvents.cs
+++ b/src/MacroTools/Setup/CustomPlayerUnitEvents.cs
@@ -41,17 +41,11 @@ public static class CustomPlayerUnitEvents
 
   static CustomPlayerUnitEvents()
   {
-    PlayerUnitEvents.AddCustomEvent(PlayerFinishesTraining, () => @event.TrainedUnit.Owner.Id,
-      playerunitevent.TrainFinish);
-    PlayerUnitEvents.AddCustomEvent(PlayerDealsDamage, () => @event.DamageSource.Owner.Id,
-      playerunitevent.Damaged);
-    PlayerUnitEvents.AddCustomEvent(PlayerTakesDamage, () => @event.Unit.Owner.Id,
-      playerunitevent.Damaged);
-    PlayerUnitEvents.AddCustomEvent(PlayerUnitDies, () => @event.Unit.Owner.Id,
-      playerunitevent.Death);
-    PlayerUnitEvents.AddCustomEvent(FactionUnitKills, () => @event.KillingUnit.Owner.GetFaction().Id,
-      playerunitevent.Death);
-    PlayerUnitEvents.AddCustomEvent(PlayerSpellEffect, () => @event.Unit.Owner.Id,
-      playerunitevent.SpellEffect);
+    PlayerUnitEvents.AddCustomEvent(PlayerFinishesTraining, () => @event.TrainedUnit.Owner.Id, playerunitevent.TrainFinish);
+    PlayerUnitEvents.AddCustomEvent(PlayerDealsDamage, () => @event.DamageSource.Owner.Id, playerunitevent.Damaged);
+    PlayerUnitEvents.AddCustomEvent(PlayerTakesDamage, () => @event.Unit.Owner.Id, playerunitevent.Damaged);
+    PlayerUnitEvents.AddCustomEvent(PlayerUnitDies, () => @event.Unit.Owner.Id, playerunitevent.Death);
+    PlayerUnitEvents.AddCustomEvent(FactionUnitKills, () => @event.KillingUnit.Owner.GetPlayerData().Faction.Id, playerunitevent.Death);
+    PlayerUnitEvents.AddCustomEvent(PlayerSpellEffect, () => @event.Unit.Owner.Id, playerunitevent.SpellEffect);
   }
 }

--- a/src/MacroTools/Systems/CinematicMode.cs
+++ b/src/MacroTools/Systems/CinematicMode.cs
@@ -100,9 +100,9 @@ public static class CinematicMode
 
   private static void PlayFactionMusic()
   {
-    foreach (var player in Util.EnumeratePlayers())
+    foreach (var player in Util.EnumeratePlayers(playerslotstate.Playing, mapcontrol.User))
     {
-      var faction = player.GetFaction();
+      var faction = player.GetPlayerData().Faction;
       if (faction != null)
       {
         player.PlayMusicThematic(faction.CinematicMusic);

--- a/src/MacroTools/Systems/GameTime.cs
+++ b/src/MacroTools/Systems/GameTime.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using MacroTools.Extensions;
+using WCSharp.Shared;
 
 namespace MacroTools.Systems;
 
@@ -76,29 +77,29 @@ public static class GameTime
     _turnTimerDialog.SetTitle($"Turn {_turnCount}");
     if (_turnCount >= 20)
     {
-      foreach (var player in WCSharp.Shared.Util.EnumeratePlayers(playerslotstate.Playing, mapcontrol.User))
+      foreach (var player in Util.EnumeratePlayers(playerslotstate.Playing, mapcontrol.User))
       {
-        var faction = player.GetFaction();
-        var meetEliminationThreshold = player.GetControlPoints().Count <= 5 && player.FoodUsed <= 105 &&
-                                       !player.GetTeam()!.DoesTeamHaveEssentialLegend();
+        var playerData = player.GetPlayerData();
+        var meetEliminationThreshold = playerData.ControlPoints.Count <= 5 && player.FoodUsed <= 105 &&
+                                       !playerData.Team!.DoesTeamHaveEssentialLegend();
         if (meetEliminationThreshold)
         {
-          if (PlayerData.ByHandle(player).EliminationTurns >= 3)
+          if (playerData.EliminationTurns >= 3)
           {
-            faction?.Defeat();
+            playerData.Faction?.Defeat();
           }
           else
           {
-            player.DisplayTextTo(PlayerData.ByHandle(player).EliminationTurns == 2
+            player.DisplayTextTo(playerData.EliminationTurns == 2
                 ? $"You have met the threshold for being eliminated from the game. Unless you raise your Control Point count above 5, raise food used above 105 or your team retakes/gains an essential Legend you will be defeated in {3 - PlayerData.ByHandle(player).EliminationTurns} turn."
                 : $"You have met the threshold for being eliminated from the game. Unless you raise your cp count above 5, raise food used above 105 or your team retakes/gains an essential Legend you will be defeated in {3 - PlayerData.ByHandle(player).EliminationTurns} turns.");
           }
 
-          PlayerData.ByHandle(player).EliminationTurns++;
+          playerData.EliminationTurns++;
         }
         else
         {
-          PlayerData.ByHandle(player).EliminationTurns = 0;
+          playerData.EliminationTurns = 0;
         }
       }
     }

--- a/src/TestMap.Source/Setup/AllFactionSetup.cs
+++ b/src/TestMap.Source/Setup/AllFactionSetup.cs
@@ -13,17 +13,18 @@ public static class AllFactionSetup
 
   private static void SetupPlayer(player player, Faction faction)
   {
+    var playerData = player.GetPlayerData();
     var traditionalTeam = faction.TraditionalTeam;
     if (traditionalTeam != null)
     {
-      player.SetTeam(traditionalTeam);
+      playerData.SetTeam(traditionalTeam);
     }
     else
     {
       throw new InvalidOperationException($"{GetPlayerName(player)}'s {nameof(Faction)} doesn't have a {nameof(Faction.TraditionalTeam)}.");
     }
 
-    player.SetFaction(faction);
+    playerData.Faction = faction;
     FactionManager.Register(faction);
   }
 }

--- a/src/WarcraftLegacies.Source/Commands/InviteCommand.cs
+++ b/src/WarcraftLegacies.Source/Commands/InviteCommand.cs
@@ -15,6 +15,7 @@ public static class InviteCommand
   {
     var enteredString = @event.PlayerChatString;
     var triggerPlayer = @event.Player;
+    var triggerPlayerData = triggerPlayer.GetPlayerData();
 
     if (SubString(enteredString, 0, StringLength(Command)) != Command)
     {
@@ -30,7 +31,7 @@ public static class InviteCommand
       return;
     }
 
-    if (triggerPlayer.GetFaction() == targetFaction)
+    if (triggerPlayerData.Faction == targetFaction)
     {
       triggerPlayer.DisplayTextTo("You can'invite yourself to your own team.");
       return;
@@ -44,7 +45,7 @@ public static class InviteCommand
 
     if (targetFaction.Player != null)
     {
-      triggerPlayer.GetTeam()?.Invite(targetFaction.Player);
+      triggerPlayerData.Team?.Invite(targetFaction.Player);
     }
   }
 

--- a/src/WarcraftLegacies.Source/Commands/JoinCommand.cs
+++ b/src/WarcraftLegacies.Source/Commands/JoinCommand.cs
@@ -28,9 +28,10 @@ public static class JoinCommand
     {
       if (targetTeam.IsPlayerInvited(triggerPlayer))
       {
-        triggerPlayer.SetTeam(targetTeam);
+        var triggerPlayerData = triggerPlayer.GetPlayerData();
+        triggerPlayerData.SetTeam(targetTeam);
         triggerPlayer.DisplayTextTo($"You have joined {targetTeam.Name}.");
-        targetTeam.DisplayText($"{triggerPlayer?.GetFaction()?.ColoredName} has joined the {targetTeam.Name}.");
+        targetTeam.DisplayText($"{triggerPlayerData.Faction?.ColoredName} has joined the {targetTeam.Name}.");
       }
       else
       {

--- a/src/WarcraftLegacies.Source/Commands/UnallyCommand.cs
+++ b/src/WarcraftLegacies.Source/Commands/UnallyCommand.cs
@@ -15,7 +15,7 @@ public static class UnallyCommand
   private static void Actions()
   {
     var triggerPlayer = @event.Player;
-    triggerPlayer.GetFaction()?.Unally();
+    triggerPlayer.GetPlayerData().Faction?.Unally();
   }
 
   public static void Setup()

--- a/src/WarcraftLegacies.Source/Commands/UninviteCommand.cs
+++ b/src/WarcraftLegacies.Source/Commands/UninviteCommand.cs
@@ -15,6 +15,7 @@ public static class UninviteCommand
   {
     var enteredString = @event.PlayerChatString;
     var triggerPlayer = @event.Player;
+    var triggerPlayerData = triggerPlayer.GetPlayerData();
 
     if (SubString(enteredString, 0, StringLength(Command)) != Command)
     {
@@ -28,7 +29,7 @@ public static class UninviteCommand
     {
       if (targetFaction.Player != null)
       {
-        triggerPlayer.GetTeam()?.Uninvite(targetFaction.Player);
+        triggerPlayerData.Team?.Uninvite(targetFaction.Player);
       }
       else
       {

--- a/src/WarcraftLegacies.Source/FactionMechanics/Scourge/Blight/BlightSystem.cs
+++ b/src/WarcraftLegacies.Source/FactionMechanics/Scourge/Blight/BlightSystem.cs
@@ -7,7 +7,7 @@ using WCSharp.Shared.Data;
 namespace WarcraftLegacies.Source.FactionMechanics.Scourge.Blight;
 
 /// <summary>
-///   Units can be registered to the <see cref="BlightSystem" /> so that when they are killed by allies of a specicic
+///   Units can be registered to the <see cref="BlightSystem" /> so that when they are killed by allies of a specific
 ///   <see cref="Faction" />, they spread a certain amount of blight around them.
 /// </summary>
 public static class BlightSystem
@@ -22,14 +22,16 @@ public static class BlightSystem
     var triggerUnit = @event.Unit;
     var parameters = _blightParameters[triggerUnit];
 
-    if (_blightFaction?.Player?.GetTeam() is null || _blightFaction.Player is null ||
-        !_blightFaction.Player.GetTeam()?.Contains(@event.KillingUnit.Owner) != true)
+    var blightPlayer = _blightFaction?.Player;
+    var blightTeam = blightPlayer?.GetPlayerData().Team;
+    var killerPlayer = @event.KillingUnit.Owner;
+
+    if (blightPlayer == null || blightTeam == null || !blightTeam.Contains(killerPlayer))
     {
       return;
     }
 
-    SetBlightRadius(_blightFaction.Player, new Point(triggerUnit.X, triggerUnit.Y),
-      parameters.PrimaryBlightRadius, true);
+    SetBlightRadius(blightPlayer, new Point(triggerUnit.X, triggerUnit.Y), parameters.PrimaryBlightRadius, true);
     if (parameters.RandomBlightRectangle is null)
     {
       return;
@@ -37,8 +39,7 @@ public static class BlightSystem
 
     for (var i = 0; i < parameters.RandomBlightCount; i++)
     {
-      SetBlightRadius(_blightFaction.Player, parameters.RandomBlightRectangle.GetRandomPoint(),
-        parameters.RandomBlightRadius, true);
+      SetBlightRadius(blightPlayer, parameters.RandomBlightRectangle.GetRandomPoint(), parameters.RandomBlightRadius, true);
     }
   }
 

--- a/src/WarcraftLegacies.Source/Factions/Legion.cs
+++ b/src/WarcraftLegacies.Source/Factions/Legion.cs
@@ -89,7 +89,7 @@ public sealed class Legion : Faction
       {
         IconName = "achievement_raid_argusraid",
         Name = "Rematerialization",
-        EligibilityCondition = dyingUnit => dyingUnit.Owner.GetObjectLimit(dyingUnit.UnitType) != 0
+        EligibilityCondition = dyingUnit => dyingUnit.Owner.GetPlayerData().GetObjectLimit(dyingUnit.UnitType) != 0
       }));
   }
 

--- a/src/WarcraftLegacies.Source/Factions/Lordaeron.cs
+++ b/src/WarcraftLegacies.Source/Factions/Lordaeron.cs
@@ -378,7 +378,7 @@ public sealed class Lordaeron : Faction
     ownerChangeTrigger.AddAction(() =>
     {
       var lordaeronPlayer = Player;
-      if (lordaeronPlayer?.GetTeam()?.Contains(@event.Unit.Owner) == true)
+      if (lordaeronPlayer?.GetPlayerData().Team?.Contains(@event.Unit.Owner) == true)
       {
         return;
       }

--- a/src/WarcraftLegacies.Source/GameLogic/CleanupUnoccupiedPlayerSlots.cs
+++ b/src/WarcraftLegacies.Source/GameLogic/CleanupUnoccupiedPlayerSlots.cs
@@ -26,14 +26,13 @@ public static class CleanupUnoccupiedPlayerSlots
 
       foreach (var player in Util.EnumeratePlayers())
       {
-        var playerFaction = player.GetFaction();
+        var playerFaction = player.GetPlayerData().Faction;
         if (playerFaction == null)
         {
           continue;
         }
 
-        if (player.SlotState != playerslotstate.Playing &&
-            playerFaction.ScoreStatus == ScoreStatus.Undefeated)
+        if (player.SlotState != playerslotstate.Playing && playerFaction.ScoreStatus == ScoreStatus.Undefeated)
         {
           playerFaction.Defeat();
         }

--- a/src/WarcraftLegacies.Source/GameLogic/DisplayIntroText.cs
+++ b/src/WarcraftLegacies.Source/GameLogic/DisplayIntroText.cs
@@ -19,9 +19,9 @@ public static class DisplayIntroText
     {
       try
       {
-        foreach (var player1 in Util.EnumeratePlayers())
+        foreach (var player in Util.EnumeratePlayers(playerslotstate.Playing, mapcontrol.User))
         {
-          player1.DisplayTextTo(player1.GetFaction()?.IntroText ?? "");
+          player.DisplayTextTo(player.GetPlayerData().Faction?.IntroText ?? "");
         }
 
         @event.ExpiredTimer.Dispose();

--- a/src/WarcraftLegacies.Source/GameLogic/GameEnd/ControlPointVictory.cs
+++ b/src/WarcraftLegacies.Source/GameLogic/GameEnd/ControlPointVictory.cs
@@ -38,7 +38,7 @@ public static class ControlPointVictory
   private static int GetTeamControlPoints(Team whichTeam) =>
     whichTeam.GetAllFactions()
       .Where(faction => faction.Player != null)
-      .Sum(faction => faction.Player.GetControlPointCount());
+      .Sum(faction => faction.Player!.GetPlayerData().ControlPoints.Count);
 
   private static void TeamWarning(Team whichTeam, int controlPoints)
   {
@@ -55,7 +55,7 @@ public static class ControlPointVictory
       return;
     }
 
-    var newOwnerTeam = controlPoint.Owner.GetTeam();
+    var newOwnerTeam = controlPoint.Owner.GetPlayerData().Team;
 
     var teamControlPoints = GetTeamControlPoints(newOwnerTeam);
     if (teamControlPoints >= CpsVictory)

--- a/src/WarcraftLegacies.Source/GameLogic/GameEnd/PlayerLeaves.cs
+++ b/src/WarcraftLegacies.Source/GameLogic/GameEnd/PlayerLeaves.cs
@@ -16,9 +16,9 @@ public static class PlayerLeaves
     {
       var triggerPlayer = @event.Player;
 
-      var playerFaction = triggerPlayer.GetFaction();
+      var playerFaction = triggerPlayer.GetPlayerData().Faction;
 
-      foreach (var player in Util.EnumeratePlayers())
+      foreach (var player in Util.EnumeratePlayers(playerslotstate.Playing, mapcontrol.User))
       {
         player.DisplayTextTo(playerFaction != null
             ? $"{playerFaction.ColoredName} has left the game."

--- a/src/WarcraftLegacies.Source/GameLogic/HeroGlowFix.cs
+++ b/src/WarcraftLegacies.Source/GameLogic/HeroGlowFix.cs
@@ -18,6 +18,7 @@ public static class HeroGlowFix
     PlayerUnitEvents.Register(HeroTypeEvent.FinishesRevive, () =>
     {
       var triggerUnit = @event.Unit;
+      var triggerPlayer = @event.Player;
       var revivedLegend = LegendaryHeroManager.GetFromUnit(triggerUnit);
       if (revivedLegend?.HasCustomColor == true)
       {
@@ -25,7 +26,7 @@ public static class HeroGlowFix
       }
       else
       {
-        triggerUnit.SetColor(@event.Player?.GetFaction()?.PlayerColor ?? playercolor.Coal);
+        triggerUnit.SetColor(triggerPlayer.GetPlayerData().Faction?.PlayerColor ?? playercolor.Coal);
       }
     });
   }

--- a/src/WarcraftLegacies.Source/GameLogic/RefundZeroLimitUnits.cs
+++ b/src/WarcraftLegacies.Source/GameLogic/RefundZeroLimitUnits.cs
@@ -13,7 +13,7 @@ public static class RefundZeroLimitUnits
   {
     var unitType = whichUnit.UnitType;
     var player = whichUnit.Owner;
-    if (player.GetObjectLimit(unitType) != 0)
+    if (player.GetPlayerData().GetObjectLimit(unitType) != 0)
     {
       return;
     }

--- a/src/WarcraftLegacies.Source/GameLogic/StartingQuestPopup.cs
+++ b/src/WarcraftLegacies.Source/GameLogic/StartingQuestPopup.cs
@@ -21,9 +21,9 @@ public static class StartingQuestPopup
     trig.RegisterTimerEvent(timeToDisplay, false);
     trig.AddAction(() =>
     {
-      foreach (var player in Util.EnumeratePlayers())
+      foreach (var player in Util.EnumeratePlayers(playerslotstate.Playing, mapcontrol.User))
       {
-        var playerFaction = player.GetFaction();
+        var playerFaction = player.GetPlayerData().Faction;
         if (playerFaction?.StartingQuest != null)
         {
           playerFaction.DisplayDiscovered(playerFaction.StartingQuest, true);

--- a/src/WarcraftLegacies.Source/GameLogic/StartingResources.cs
+++ b/src/WarcraftLegacies.Source/GameLogic/StartingResources.cs
@@ -19,7 +19,7 @@ public static class StartingResources
     {
       foreach (var player in Util.EnumeratePlayers())
       {
-        var faction = player.GetFaction();
+        var faction = player.GetPlayerData().Faction;
         if (faction == null)
         {
           continue;

--- a/src/WarcraftLegacies.Source/GameModes/GameModeExtensions.cs
+++ b/src/WarcraftLegacies.Source/GameModes/GameModeExtensions.cs
@@ -15,24 +15,23 @@ public static class GameModeExtensions
   public static IGameMode SetupGreatWarTeams(this IGameMode gameMode)
   {
     FactionManager.SharedVisionMode = TeamSharedVisionMode.TraditionalAlliesOnly;
-    player.Create(6).SetTeam(TeamSetup.Legion);
-    player.Create(15).SetTeam(TeamSetup.Legion);
-    player.Create(9).SetTeam(TeamSetup.Legion);
-    player.Create(2).SetTeam(TeamSetup.Legion);
-    player.Create(7).SetTeam(TeamSetup.Legion);
-    player.Create(12).SetTeam(TeamSetup.Legion);
-    player.Create(16).SetTeam(TeamSetup.Legion);
-    player.Create(8).SetTeam(TeamSetup.Legion);
+    player.Create(6).GetPlayerData().SetTeam(TeamSetup.Legion);
+    player.Create(15).GetPlayerData().SetTeam(TeamSetup.Legion);
+    player.Create(9).GetPlayerData().SetTeam(TeamSetup.Legion);
+    player.Create(2).GetPlayerData().SetTeam(TeamSetup.Legion);
+    player.Create(7).GetPlayerData().SetTeam(TeamSetup.Legion);
+    player.Create(12).GetPlayerData().SetTeam(TeamSetup.Legion);
+    player.Create(16).GetPlayerData().SetTeam(TeamSetup.Legion);
+    player.Create(8).GetPlayerData().SetTeam(TeamSetup.Legion);
 
-    player.Create(3).SetTeam(TeamSetup.Alliance);
-    player.Create(23).SetTeam(TeamSetup.Alliance);
-    player.Create(1).SetTeam(TeamSetup.Alliance);
-    player.Create(4).SetTeam(TeamSetup.Alliance);
-    player.Create(22).SetTeam(TeamSetup.Alliance);
-    player.Create(0).SetTeam(TeamSetup.Alliance);
-    player.Create(11).SetTeam(TeamSetup.Alliance);
-    player.Create(18).SetTeam(TeamSetup.Alliance);
-
+    player.Create(3).GetPlayerData().SetTeam(TeamSetup.Alliance);
+    player.Create(23).GetPlayerData().SetTeam(TeamSetup.Alliance);
+    player.Create(1).GetPlayerData().SetTeam(TeamSetup.Alliance);
+    player.Create(4).GetPlayerData().SetTeam(TeamSetup.Alliance);
+    player.Create(22).GetPlayerData().SetTeam(TeamSetup.Alliance);
+    player.Create(0).GetPlayerData().SetTeam(TeamSetup.Alliance);
+    player.Create(11).GetPlayerData().SetTeam(TeamSetup.Alliance);
+    player.Create(18).GetPlayerData().SetTeam(TeamSetup.Alliance);
 
     SharedQuestRepository.RegisterQuest(new QuestSharedVision());
     return gameMode;

--- a/src/WarcraftLegacies.Source/Powers/FontOfPower.cs
+++ b/src/WarcraftLegacies.Source/Powers/FontOfPower.cs
@@ -39,7 +39,7 @@ public sealed class FontOfPower : Power
       var researchLevel = _isActive ? 1 : 0;
       foreach (var player in _playersWithPower)
       {
-        player.GetFaction()?.SetObjectLevel(ResearchId, researchLevel);
+        player.GetPlayerData().Faction?.SetObjectLevel(ResearchId, researchLevel);
       }
     }
   }

--- a/src/WarcraftLegacies.Source/Quests/Druids/QuestAndrassil.cs
+++ b/src/WarcraftLegacies.Source/Quests/Druids/QuestAndrassil.cs
@@ -50,7 +50,7 @@ public sealed class QuestAndrassil : QuestData
   {
     var scourgePlayer = _scourge.Player;
     return scourgePlayer != null && completingFaction.Player != null &&
-           scourgePlayer.GetTeam()?.Contains(completingFaction.Player) != false;
+           scourgePlayer.GetPlayerData().Team?.Contains(completingFaction.Player) != false;
   }
 
   /// <inheritdoc/>

--- a/src/WarcraftLegacies.Source/Quests/Gilneas/QuestGoldrinn.cs
+++ b/src/WarcraftLegacies.Source/Quests/Gilneas/QuestGoldrinn.cs
@@ -47,6 +47,6 @@ public sealed class QuestGoldrinn : QuestData
   {
     var druidsPlayer = _druids.Player;
     return druidsPlayer != null && completingFaction.Player != null &&
-           druidsPlayer.GetTeam()?.Contains(completingFaction.Player) != false;
+           druidsPlayer.GetPlayerData().Team?.Contains(completingFaction.Player) != false;
   }
 }

--- a/src/WarcraftLegacies.Source/Quests/Lordaeron/QuestScarletCrusade.cs
+++ b/src/WarcraftLegacies.Source/Quests/Lordaeron/QuestScarletCrusade.cs
@@ -80,7 +80,10 @@ public sealed class QuestScarletCrusade : QuestData
     var scarletCrusade = new ScarletCrusade(_allLegendSetup);
     FactionManager.Register(scarletCrusade);
     scarletCrusade.CopyObjectLevelsFrom(completingFaction);
-    completingFaction.Player?.SetFaction(scarletCrusade);
+    if (completingFaction.Player != null)
+    {
+      completingFaction.Player.GetPlayerData().Faction = scarletCrusade;
+    }
   }
 
   private static void EvacuateTyrsHand(player newOwner)

--- a/src/WarcraftLegacies.Source/Quests/Naga/QuestKiljaedensCommand.cs
+++ b/src/WarcraftLegacies.Source/Quests/Naga/QuestKiljaedensCommand.cs
@@ -139,7 +139,7 @@ public sealed class QuestKiljaedensCommand : QuestData
     }
 
     var factionTarget = eligibleFactions
-      .OrderByDescending(f => f.Player?.GetControlPointCount())
+      .OrderByDescending(f => f.Player?.GetPlayerData().ControlPoints.Count)
       .First();
     SetQuestTarget(factionTarget);
   }

--- a/src/WarcraftLegacies.Source/Quests/QuestZinrokhAssembly.cs
+++ b/src/WarcraftLegacies.Source/Quests/QuestZinrokhAssembly.cs
@@ -35,7 +35,7 @@ public sealed class QuestZinrokhAssembly : QuestData
 
   /// <inheritdoc/>
   public override string PenaltyFlavour =>
-    $"{_fragments.First().OwningPlayer?.GetFaction()?.ColoredName ?? ""} has assembled Zin'rokh, Destroyer of Worlds. The only way we will acquire it now is if we take it from them.";
+    $"{_fragments.First().OwningPlayer?.GetPlayerData().Faction?.ColoredName ?? ""} has assembled Zin'rokh, Destroyer of Worlds. The only way we will acquire it now is if we take it from them.";
 
   /// <inheritdoc/>
   protected override string RewardDescription => "Reforge Zin'rokh, Destroyer of Worlds from its Shards";

--- a/src/WarcraftLegacies.Source/Quests/Scourge/QuestPlague.cs
+++ b/src/WarcraftLegacies.Source/Quests/Scourge/QuestPlague.cs
@@ -193,7 +193,7 @@ public sealed class QuestPlague : QuestData
       return;
     }
 
-    foreach (var controlPoint in _plagueVictim.Player.GetControlPoints())
+    foreach (var controlPoint in _plagueVictim.Player.GetPlayerData().ControlPoints)
     {
       controlPoint.ControlLevel = 0;
     }

--- a/src/WarcraftLegacies.Source/Quests/Scourge/QuestSapphiron.cs
+++ b/src/WarcraftLegacies.Source/Quests/Scourge/QuestSapphiron.cs
@@ -41,20 +41,33 @@ public sealed class QuestSapphiron : QuestData
   /// <inheritdoc/>
   protected override void OnComplete(Faction completingFaction)
   {
-    if (_unitIsDeadObjective.KillingUnit == null)
+    var killingUnit = _unitIsDeadObjective.KillingUnit;
+    if (killingUnit == null)
     {
       return;
     }
 
-    var killingPlayer = _unitIsDeadObjective.KillingUnit.Owner;
+    var killingPlayer = killingUnit.Owner;
     if (killingPlayer == null)
     {
       return;
     }
 
-    if (completingFaction.Player?.GetTeam()?.Contains(killingPlayer) == true)
+    var completingPlayer = completingFaction.Player;
+    if (completingPlayer == null)
     {
-      unit.Create(completingFaction.Player, SapphironId, -2600, 18800, 300);
+      return;
+    }
+
+    var completingTeam = completingPlayer.GetPlayerData().Team;
+    if (completingTeam == null)
+    {
+      return;
+    }
+
+    if (completingTeam.Contains(killingPlayer))
+    {
+      unit.Create(completingPlayer, SapphironId, -2600, 18800, 300);
     }
   }
 }

--- a/src/WarcraftLegacies.Source/Quests/Scourge/QuestSlumberingKing.cs
+++ b/src/WarcraftLegacies.Source/Quests/Scourge/QuestSlumberingKing.cs
@@ -39,9 +39,26 @@ public sealed class QuestSlumberingKing : QuestData
   {
     get
     {
+      var name = "unit";
+      var factionName = "an unknown faction";
+
       var completingUnit = _anyEnemyUnitInRectsObjective.CompletingUnit;
-      return
-        $"A {completingUnit.Name} under the control of {(completingUnit != null ? completingUnit.Owner : null).GetFaction()?.ColoredName} has encroached on the shores of Northrend. Soon they will feel the biting chill of death.";
+      if (completingUnit != null)
+      {
+        name = completingUnit.Name;
+
+        var owner = completingUnit.Owner;
+        if (owner != null)
+        {
+          var faction = owner.GetPlayerData().Faction;
+          if (faction != null)
+          {
+            factionName = faction.ColoredName;
+          }
+        }
+      }
+
+      return $"A {name} under the control of {factionName} has encroached on the shores of Northrend. Soon they will feel the biting chill of death.";
     }
   }
 

--- a/src/WarcraftLegacies.Source/Quests/Skywall/QuestFirelandInvasion.cs
+++ b/src/WarcraftLegacies.Source/Quests/Skywall/QuestFirelandInvasion.cs
@@ -133,7 +133,7 @@ public sealed class QuestFirelandInvasion : QuestData
       return;
     }
 
-    foreach (var controlPoint in _invasionVictim.Player.GetControlPoints())
+    foreach (var controlPoint in _invasionVictim.Player.GetPlayerData().ControlPoints)
     {
       controlPoint.ControlLevel = 0;
     }

--- a/src/WarcraftLegacies.Source/Researches/PowerResearch.cs
+++ b/src/WarcraftLegacies.Source/Researches/PowerResearch.cs
@@ -15,5 +15,5 @@ public sealed class PowerResearch : Research
   public PowerResearch(int researchTypeId, int goldCost, Power power) : base(researchTypeId, goldCost) => _power = power;
 
   /// <inheritdoc />
-  public override void OnResearch(player researchingPlayer) => researchingPlayer.GetFaction()?.AddPower(_power);
+  public override void OnResearch(player researchingPlayer) => researchingPlayer.GetPlayerData().Faction?.AddPower(_power);
 }

--- a/src/WarcraftLegacies.Source/Researches/RemoveAbilityResearch.cs
+++ b/src/WarcraftLegacies.Source/Researches/RemoveAbilityResearch.cs
@@ -21,7 +21,7 @@ public sealed class RemoveAbilityResearch : Research
   /// <inheritdoc />
   public override void OnResearch(player researchingPlayer)
   {
-    var faction = researchingPlayer.GetFaction();
+    var faction = researchingPlayer.GetPlayerData().Faction;
     faction?.ModAbilityAvailability(RemovedAbility, -1);
   }
 }

--- a/src/WarcraftLegacies.Source/Researches/Stormwind/TierCodeOfChivalry.cs
+++ b/src/WarcraftLegacies.Source/Researches/Stormwind/TierCodeOfChivalry.cs
@@ -8,8 +8,10 @@ public static class TierCodeOfChivalry
 {
   private static void Research()
   {
-    @event.Player.GetFaction()?.ModObjectLimit(UNIT_H01B_OUTRIDER_STORMWIND, -Faction.Unlimited);
-    @event.Player.GetFaction()?.ModObjectLimit(UNIT_H054_STORMWIND_KNIGHT_STORMWIND, Faction.Unlimited);
+    var triggerPlayer = @event.Player;
+    var triggerPlayerData = triggerPlayer.GetPlayerData();
+    triggerPlayerData.Faction?.ModObjectLimit(UNIT_H01B_OUTRIDER_STORMWIND, -Faction.Unlimited);
+    triggerPlayerData.Faction?.ModObjectLimit(UNIT_H054_STORMWIND_KNIGHT_STORMWIND, Faction.Unlimited);
   }
 
   public static void Setup()

--- a/src/WarcraftLegacies.Source/Researches/Stormwind/TierExpeditionSurvivors.cs
+++ b/src/WarcraftLegacies.Source/Researches/Stormwind/TierExpeditionSurvivors.cs
@@ -8,8 +8,8 @@ public static class TierExpeditionSurvivors
 {
   private static void Research()
   {
-    @event.Player.GetFaction()?.ModObjectLimit(UNIT_H00A_SPEARMAN_STORMWIND, -Faction.Unlimited);
-    @event.Player.GetFaction()?.ModObjectLimit(UNIT_H05N_MARKSMAN_STORMWIND, Faction.Unlimited);
+    @event.Player.GetPlayerData().Faction?.ModObjectLimit(UNIT_H00A_SPEARMAN_STORMWIND, -Faction.Unlimited);
+    @event.Player.GetPlayerData().Faction?.ModObjectLimit(UNIT_H05N_MARKSMAN_STORMWIND, Faction.Unlimited);
   }
 
   public static void Setup()

--- a/src/WarcraftLegacies.Source/Researches/Stormwind/TierReflectivePlating.cs
+++ b/src/WarcraftLegacies.Source/Researches/Stormwind/TierReflectivePlating.cs
@@ -8,8 +8,10 @@ public static class TierReflectivePlating
 {
   private static void Research()
   {
-    @event.Player.GetFaction()?.ModObjectLimit(UNIT_H04C_PIKEMAN_STORMWIND, Faction.Unlimited);
-    @event.Player.GetFaction()?.ModObjectLimit(UNIT_H02O_BLADESMAN_STORMWIND, -Faction.Unlimited);
+    var triggerPlayer = @event.Player;
+    var triggerPlayerData = triggerPlayer.GetPlayerData();
+    triggerPlayerData.Faction?.ModObjectLimit(UNIT_H04C_PIKEMAN_STORMWIND, Faction.Unlimited);
+    triggerPlayerData.Faction?.ModObjectLimit(UNIT_H02O_BLADESMAN_STORMWIND, -Faction.Unlimited);
   }
 
   public static void Setup()

--- a/src/WarcraftLegacies.Source/Researches/Stormwind/TierVeteranGuard.cs
+++ b/src/WarcraftLegacies.Source/Researches/Stormwind/TierVeteranGuard.cs
@@ -8,8 +8,8 @@ public static class TierVeteranGuard
 {
   private static void Research()
   {
-    @event.Player.GetFaction()?.ModObjectLimit(UNIT_H03K_MARSHAL_STORMWIND, -Faction.Unlimited);
-    @event.Player.GetFaction()?.ModObjectLimit(UNIT_H03U_REAR_MARSHAL_STORMWIND_DEFENSIVE, 12);
+    @event.Player.GetPlayerData().Faction?.ModObjectLimit(UNIT_H03K_MARSHAL_STORMWIND, -Faction.Unlimited);
+    @event.Player.GetPlayerData().Faction?.ModObjectLimit(UNIT_H03U_REAR_MARSHAL_STORMWIND_DEFENSIVE, 12);
   }
 
   public static void Setup()

--- a/src/WarcraftLegacies.Source/Researches/SunfuryWarrior.cs
+++ b/src/WarcraftLegacies.Source/Researches/SunfuryWarrior.cs
@@ -18,7 +18,7 @@ public sealed class SunfuryWarrior : Research
   /// <inheritdoc />
   public override void OnResearch(player researchingPlayer)
   {
-    var faction = researchingPlayer.GetFaction();
+    var faction = researchingPlayer.GetPlayerData().Faction;
     faction?.ModObjectLimit(UNIT_HHES_SWORDSMAN_QUELTHALAS, -Faction.Unlimited);
     faction?.ModObjectLimit(UNIT_NBEL_SUNFURY_WARRIOR_QUELTHALAS, Faction.Unlimited);
   }

--- a/src/WarcraftLegacies.Source/Researches/VeteranFootmen.cs
+++ b/src/WarcraftLegacies.Source/Researches/VeteranFootmen.cs
@@ -18,7 +18,7 @@ public sealed class VeteranFootmen : Research
   /// <inheritdoc />
   public override void OnResearch(player researchingPlayer)
   {
-    var faction = researchingPlayer.GetFaction();
+    var faction = researchingPlayer.GetPlayerData().Faction;
     faction?.ModObjectLimit(UNIT_HFOO_FOOTMAN_LORDAERON, -Faction.Unlimited);
     faction?.ModObjectLimit(UNIT_H029_VETERAN_FOOTMAN_LORDAERON, Faction.Unlimited);
   }

--- a/src/WarcraftLegacies.Source/Researches/Warsong/MoknathalWarrior.cs
+++ b/src/WarcraftLegacies.Source/Researches/Warsong/MoknathalWarrior.cs
@@ -18,8 +18,11 @@ public sealed class MoknathalWarrior : Research
   /// <inheritdoc />
   public override void OnResearch(player researchingPlayer)
   {
-    var faction = researchingPlayer.GetFaction();
-    faction?.ModObjectLimit(UNIT_HFOO_FOOTMAN_LORDAERON, -Faction.Unlimited);
-    faction?.ModObjectLimit(UNIT_H029_VETERAN_FOOTMAN_LORDAERON, Faction.Unlimited);
+    var faction = researchingPlayer.GetPlayerData().Faction;
+    if (faction != null)
+    {
+      faction.ModObjectLimit(UNIT_HFOO_FOOTMAN_LORDAERON, -Faction.Unlimited);
+      faction.ModObjectLimit(UNIT_H029_VETERAN_FOOTMAN_LORDAERON, Faction.Unlimited);
+    }
   }
 }

--- a/src/WarcraftLegacies.Source/Setup/PlayerSetup.cs
+++ b/src/WarcraftLegacies.Source/Setup/PlayerSetup.cs
@@ -26,15 +26,15 @@ public sealed class PlayerSetup
     SetupPlayer(player.Create(3), new Scourge(_preplacedUnitSystem, _allLegendSetup, _artifactSetup));
     SetupPlayer(player.Create(4), new Ironforge(_preplacedUnitSystem, _allLegendSetup, _artifactSetup));
     SetupPlayer(player.Create(6), new FelHorde(_preplacedUnitSystem, _allLegendSetup, _artifactSetup));
-    player.Create(7).SetTeam(TeamSetup.NorthAlliance);
-    player.Create(0).SetTeam(TeamSetup.Kalimdor);
+    player.Create(7).GetPlayerData().SetTeam(TeamSetup.NorthAlliance);
+    player.Create(0).GetPlayerData().SetTeam(TeamSetup.Kalimdor);
     SetupPlayer(player.Create(8), new Skywall(_allLegendSetup));
     SetupPlayer(player.Create(9), new Lordaeron(_preplacedUnitSystem, _allLegendSetup, _artifactSetup));
     SetupPlayer(player.Create(11), new Druids(_preplacedUnitSystem, _allLegendSetup, _artifactSetup));
     SetupPlayer(player.Create(12), new BlackEmpire(_preplacedUnitSystem, _allLegendSetup));
     SetupPlayer(player.Create(16), new Ahnqiraj(_preplacedUnitSystem, _allLegendSetup));
-    player.Create(18).SetTeam(TeamSetup.Kalimdor);
-    player.Create(15).SetTeam(TeamSetup.Outland);
+    player.Create(18).GetPlayerData().SetTeam(TeamSetup.Kalimdor);
+    player.Create(15).GetPlayerData().SetTeam(TeamSetup.Outland);
     SetupPlayer(player.Create(22), new Kultiras(_preplacedUnitSystem, _allLegendSetup, _artifactSetup));
     SetupPlayer(player.Create(23), new Legion(_preplacedUnitSystem, _allLegendSetup));
   }
@@ -45,14 +45,14 @@ public sealed class PlayerSetup
     var traditionalTeam = faction.TraditionalTeam;
     if (traditionalTeam != null)
     {
-      player.SetTeam(traditionalTeam);
+      player.GetPlayerData().SetTeam(traditionalTeam);
     }
     else
     {
       throw new InvalidOperationException($"{player.Name}'s {nameof(Faction)} doesn't have a {nameof(Faction.TraditionalTeam)}.");
     }
 
-    player.SetFaction(faction);
+    player.GetPlayerData().Faction = faction;
     FactionManager.Register(faction);
   }
 }

--- a/src/WarcraftLegacies.Source/Spells/PingOilDeposits.cs
+++ b/src/WarcraftLegacies.Source/Spells/PingOilDeposits.cs
@@ -26,7 +26,7 @@ public sealed class PingOilDeposits : Spell
   /// <inheritdoc />
   public override void OnCast(unit caster, unit target, Point targetPoint)
   {
-    var oilPower = @event.Unit.Owner.GetFaction()?.GetPowerByType<OilPower>();
+    var oilPower = @event.Unit.Owner.GetPlayerData().Faction?.GetPowerByType<OilPower>();
     if (oilPower == null)
     {
       return;


### PR DESCRIPTION
This PR proposes exposing `PlayerData` publicly and removing extension methods that simply mirror its internal properties. Instead of maintaining public extensions for an internal class, the properties are now accessed directly.

This change removes parallel constructs and avoids cases where logic might diverge between an extension method and the property it wraps. It also makes the distinction between the native `player` object and the associated `PlayerData` explicit.

This refactor also reveals that `PlayerData.ByHandle` is called over 120 times. Many systems may benefit from holding a reference to `PlayerData` directly rather than storing only the `player` handle. This change could lead to future improvements in performance and code clarity.

I also included several unrelated minor bug fixes and performance improvements made while touching adjacent code, including squashing multiple potential null dereferences. Let me know if these should be separated into their own PRs