### PR TITLE
fix: normalize file paths for cross-platform compatibility

### DIFF
--- a/src/Launcher/Extensions/MapExtensions.cs
+++ b/src/Launcher/Extensions/MapExtensions.cs
@@ -217,7 +217,7 @@ public static class MapExtensions
 
       var destinationPath = Path.Combine(destinationRootDirectory, file.RelativePath);
       Directory.CreateDirectory(Path.GetDirectoryName(destinationPath));
-      File.Copy(file.AbsolutePath, Path.Combine(destinationRootDirectory, file.RelativePath), true);
+      File.Copy(file.AbsolutePath, destinationPath, true);
     }
   }
 

--- a/src/Launcher/Properties/launchSettings.json
+++ b/src/Launcher/Properties/launchSettings.json
@@ -2,39 +2,39 @@
   "profiles": {
     "TestMap: Test": {
       "commandName": "Project",
-      "commandLineArgs": "mapdata-to-w3x TestMap true \"..\\..\\..\\..\\..\\mapdata\\TestMap\" \"..\\..\\..\\..\\..\\artifacts\" --sourcecodepath \"..\\..\\..\\..\\TestMap.Source\""
+      "commandLineArgs": "mapdata-to-w3x TestMap true \"../../../../../mapdata/TestMap\" \"../../../../../artifacts\" --sourcecodepath \"../../../../TestMap.Source\""
     },
     "TestMap: Convert W3X to MapData": {
       "commandName": "Project",
-      "commandLineArgs": "w3x-to-mapdata \"..\\..\\..\\..\\..\\maps\\TestMap.w3x\" \"..\\..\\..\\..\\..\\mapdata\\TestMap\" --constantsOutputPath \"..\\..\\..\\..\\TestMap.Source\""
+      "commandLineArgs": "w3x-to-mapdata \"../../../../../maps/TestMap.w3x\" \"../../../../../mapdata/TestMap\" --constantsOutputPath \"../../../../TestMap.Source\""
     },
     "TestMap: Convert MapData to W3X": {
       "commandName": "Project",
-      "commandLineArgs": "mapdata-to-w3x TestMap false \"..\\..\\..\\..\\..\\mapdata\\TestMap\" \"..\\..\\..\\..\\..\\maps\" --backup-directory \"..\\..\\..\\..\\..\\maps\\backups\" --output-type Folder"
+      "commandLineArgs": "mapdata-to-w3x TestMap false \"../../../../../mapdata/TestMap\" \"../../../../../maps\" --backup-directory \"../../../../../maps/backups\" --output-type Folder"
     },
     "TestMap: Transpile C# to Lua": {
       "commandName": "Project",
-      "commandLineArgs": "csharp-to-lua TestMap \"..\\..\\..\\..\\..\\maps\" \"..\\..\\..\\..\\TestMap.Source\""
+      "commandLineArgs": "csharp-to-lua TestMap \"../../../../../maps\" \"../../../../TestMap.Source\""
     },
     "WarcraftLegacies: Test": {
       "commandName": "Project",
-      "commandLineArgs": "mapdata-to-w3x WarcraftLegacies true \"..\\..\\..\\..\\..\\mapdata\\WarcraftLegacies\" \"..\\..\\..\\..\\..\\artifacts\" --sourcecodepath \"..\\..\\..\\..\\WarcraftLegacies.Source\" --set-map-titles True"
+      "commandLineArgs": "mapdata-to-w3x WarcraftLegacies true \"../../../../../mapdata/WarcraftLegacies\" \"../../../../../artifacts\" --sourcecodepath \"../../../../WarcraftLegacies.Source\" --set-map-titles True"
     },
     "WarcraftLegacies: Publish": {
       "commandName": "Project",
-      "commandLineArgs": "mapdata-to-w3x WarcraftLegacies false \"..\\..\\..\\..\\..\\mapdata\\WarcraftLegacies\" \"..\\..\\..\\..\\..\\maps\\published\" --sourcecodepath \"..\\..\\..\\..\\WarcraftLegacies.Source\" --set-map-titles True"
+      "commandLineArgs": "mapdata-to-w3x WarcraftLegacies false \"../../../../../mapdata/WarcraftLegacies\" \"../../../../../maps/published\" --sourcecodepath \"../../../../WarcraftLegacies.Source\" --set-map-titles True"
     },
     "WarcraftLegacies: Convert W3X to MapData": {
       "commandName": "Project",
-      "commandLineArgs": "w3x-to-mapdata \"..\\..\\..\\..\\..\\maps\\WarcraftLegacies.w3x\" \"..\\..\\..\\..\\..\\mapdata\\WarcraftLegacies\" --constantsOutputPath \"..\\..\\..\\..\\WarcraftLegacies.Shared\" --regionsOutputPath \"..\\..\\..\\..\\WarcraftLegacies.Source\""
+      "commandLineArgs": "w3x-to-mapdata \"../../../../../maps/WarcraftLegacies.w3x\" \"../../../../../mapdata/WarcraftLegacies\" --constantsOutputPath \"../../../../WarcraftLegacies.Shared\" --regionsOutputPath \"../../../../WarcraftLegacies.Source\""
     },
     "WarcraftLegacies: Convert MapData to W3X": {
       "commandName": "Project",
-      "commandLineArgs": "mapdata-to-w3x WarcraftLegacies false \"..\\..\\..\\..\\..\\mapdata\\WarcraftLegacies\" \"..\\..\\..\\..\\..\\maps\" --backup-directory \"..\\..\\..\\..\\..\\maps\\backups\" --output-type Folder"
+      "commandLineArgs": "mapdata-to-w3x WarcraftLegacies false \"../../../../../mapdata/WarcraftLegacies\" \"../../../../../maps\" --backup-directory \"../../../../../maps/backups\" --output-type Folder"
     },
     "WarcraftLegacies: Transpile C# to Lua": {
       "commandName": "Project",
-      "commandLineArgs": "csharp-to-lua WarcraftLegacies \"..\\..\\..\\..\\..\\maps\" \"..\\..\\..\\..\\WarcraftLegacies.Source\""
+      "commandLineArgs": "csharp-to-lua WarcraftLegacies \"../../../../../maps\" \"../../../../WarcraftLegacies.Source\""
     }
   }
 }

--- a/src/Launcher/Services/AdvancedMapBuilder.cs
+++ b/src/Launcher/Services/AdvancedMapBuilder.cs
@@ -88,7 +88,7 @@ public sealed class AdvancedMapBuilder
       Directory.Delete(mapFilePath, true);
     }
 
-    map.BuildDirectory(@$"{mapFilePath}\", additionalFiles);
+    map.BuildDirectory(mapFilePath, additionalFiles);
   }
 
   private void SupplementMap(Map map, AdvancedMapBuilderOptions options)

--- a/src/Launcher/Services/MapDataToMapConverter.cs
+++ b/src/Launcher/Services/MapDataToMapConverter.cs
@@ -407,7 +407,7 @@ public sealed class MapDataToMapConverter
 
   private static IEnumerable<PathData> GetAdditionalFiles(string mapDataRootDirectory)
   {
-    var importsDirectory = $@"{mapDataRootDirectory}\{ImportsPath}";
+    var importsDirectory = Path.Combine(mapDataRootDirectory, ImportsPath);
 
     var additionalFiles = Directory.Exists(importsDirectory)
       ? Directory.EnumerateFiles(importsDirectory, "*", SearchOption.AllDirectories).Select(x => new PathData
@@ -437,7 +437,7 @@ public sealed class MapDataToMapConverter
 
   private static IEnumerable<DirectoryEnumerationOptions> GetAdditionalFileDirectories(string mapDataRootDirectory)
   {
-    var importsDirectory = $@"{mapDataRootDirectory}\{ImportsPath}";
+    var importsDirectory = Path.Combine(mapDataRootDirectory, ImportsPath);
 
     var fileDirectories = Directory.Exists(importsDirectory)
       ? new List<DirectoryEnumerationOptions>

--- a/src/Launcher/Services/W3XToMapDataConverter.cs
+++ b/src/Launcher/Services/W3XToMapDataConverter.cs
@@ -168,7 +168,7 @@ public sealed class W3XToMapDataConverter
         continue;
       }
 
-      var destinationFileName = $@"{outputFolderPath}\{ImportsPath}\{relativePath}";
+      var destinationFileName = Path.Combine(outputFolderPath, ImportsPath, relativePath);
       Directory.CreateDirectory(Path.GetDirectoryName(destinationFileName)!);
       File.Copy(file, destinationFileName, true);
     }
@@ -178,34 +178,27 @@ public sealed class W3XToMapDataConverter
   {
     foreach (var filePath in GetUnserializableFilePaths())
     {
-      var fullSourceFilePath = $"{baseMapPath}/{filePath}";
+      var fullSourceFilePath = Path.Combine(baseMapPath, filePath);
       if (!File.Exists(fullSourceFilePath))
       {
         continue;
       }
 
-      var fullOutputFilePath = $@"{outputFolderPath}\{filePath}";
-      if (fullSourceFilePath.EndsWith(".txt"))
-      {
-        //Warcraft 3 maps use CR line endings, so this ensures that those line endings are replaced with CLRF.
-        File.WriteAllLines(fullOutputFilePath, File.ReadLines(fullSourceFilePath));
-      }
-      else
-      {
-        File.Copy(fullSourceFilePath, fullOutputFilePath, true);
-      }
+      var fullOutputFilePath = Path.Combine(outputFolderPath, filePath);
+      File.Copy(fullSourceFilePath, fullOutputFilePath, true);
     }
   }
 
   private static void CopyGameInterface(string baseMapPath, TriggerStringDictionary triggerStringDictionary, string outputFolderPath)
   {
-    if (!File.Exists($"{baseMapPath}/{GameInterfacePath}"))
+    var gameInterfacePath = Path.Combine(baseMapPath, GameInterfacePath);
+    if (!File.Exists(gameInterfacePath))
     {
       return;
     }
 
-    var subtitutedText = triggerStringDictionary.SubstituteTriggerStringsInText(File.ReadAllText($"{baseMapPath}/{GameInterfacePath}"));
-    File.WriteAllText($@"{outputFolderPath}\{GameInterfacePath}", subtitutedText);
+    var subtitutedText = triggerStringDictionary.SubstituteTriggerStringsInText(File.ReadAllText(gameInterfacePath));
+    File.WriteAllText(Path.Combine(outputFolderPath, GameInterfacePath), subtitutedText);
   }
 
   /// <summary>

--- a/src/Launcher/appsettings.json
+++ b/src/Launcher/appsettings.json
@@ -1,8 +1,8 @@
 ﻿{
   "CompilerSettings": {
-    "MapDataPath": "..\\..\\..\\..\\..\\mapdata\\",
-    "ArtifactsPath": "..\\..\\..\\..\\..\\artifacts\\",
-    "SharedAssetsPath": "..\\..\\..\\..\\..\\shared_imports\\"
+    "MapDataPath": "../../../../../mapdata/",
+    "ArtifactsPath": "../../../../../artifacts/",
+    "SharedAssetsPath": "../../../../../shared_imports/"
   },
   "MapSettings": {
     "Version": "4.6.0"


### PR DESCRIPTION
Normalizes paths based on Linux.

Windows supports both `\` and `/`, but Linux only supports `/`, so paths have been updated to use forward slashes.