### PR TITLE
Use inverted endianness in UnitTooltipMigration

### DIFF
--- a/src/Launcher/MapMigrations/UnitTooltipMigration.cs
+++ b/src/Launcher/MapMigrations/UnitTooltipMigration.cs
@@ -4,6 +4,7 @@ using System.Text;
 using Launcher.Extensions;
 using War3Api.Object;
 using War3Net.Build;
+using War3Net.CodeAnalysis.Jass.Extensions;
 using WarcraftLegacies.Shared;
 
 namespace Launcher.MapMigrations;
@@ -219,7 +220,7 @@ public sealed class UnitTooltipMigration : IMapMigration
       return;
     }
 
-    var unitId = unit.NewId != 0 ? unit.NewId : unit.OldId;
+    var unitId = (unit.NewId != 0 ? unit.NewId : unit.OldId).InvertEndianness();
     if (!_objectInfoRepository.TryGetObjectInfo(unitId, out var objectLimit))
     {
       return;


### PR DESCRIPTION
https://github.com/AzerothWarsLR/WarcraftLegacies/commit/9adb048757e1b98ac1cc73b58af80ff3a4fe1ac1 changed ObjectInfoRepository to use numeric values, which for whatever reason have inverted endianness from what gets extracted by War3Net, causing the UnitTooltipMigration to break. This inverts the endianness on the UnitTooltipMigration end.