### PR TITLE
Remove unit tooltip text that is meant to be autogenerated

### DIFF
--- a/mapdata/WarcraftLegacies/UnitData/Skin/hrif.json
+++ b/mapdata/WarcraftLegacies/UnitData/Skin/hrif.json
@@ -22,7 +22,7 @@
     {
       "Id": 1651864693,
       "Type": 3,
-      "Value": "Highly skilled sharpshooter and fan of the boomstick. |cfff5962dAbilities:|R Ensnare, Spell Resistance"
+      "Value": "Highly skilled sharpshooter and fan of the boomstick."
     }
   ]
 }

--- a/mapdata/WarcraftLegacies/UnitData/Skin/n000.json
+++ b/mapdata/WarcraftLegacies/UnitData/Skin/n000.json
@@ -51,7 +51,7 @@
     {
       "Id": 1651864693,
       "Type": 3,
-      "Value": "Gateway attuned to the Fel Hounds of the Burning Crusade, summoning 1 every 30 seconds. |n|n|cfff5962dAbilities:|R Mana Burn, Magic Resistance, Feedback|n|cfff5962dUpgrades Into:|R Fel Hound Pack, Felguard or Pit Fiend Demon Gate|n|n|cff99b4d1Limit 12 per gate."
+      "Value": "Gateway attuned to the Fel Hounds of the Burning Crusade, summoning 1 every 30 seconds."
     },
     {
       "Id": 1953458293,

--- a/mapdata/WarcraftLegacies/UnitData/Skin/n059.json
+++ b/mapdata/WarcraftLegacies/UnitData/Skin/n059.json
@@ -37,7 +37,7 @@
     {
       "Id": 1651864693,
       "Type": 3,
-      "Value": "Arcane thirsting hound of the Fel.|n|cfff5962dAbilities:|R Feedback, Mana Burn |n|n|cffffcc00Attacks land units.|r|n|n|cff99b4d1Limit 12 per gate."
+      "Value": "Arcane thirsting hound of the Fel."
     }
   ]
 }

--- a/mapdata/WarcraftLegacies/UnitData/Skin/n05B.json
+++ b/mapdata/WarcraftLegacies/UnitData/Skin/n05B.json
@@ -40,7 +40,7 @@
     {
       "Id": 1651864693,
       "Type": 3,
-      "Value": "Frontline demon warrior.|n|cfff5962dAbilities:|R Charge, Critical Strike, Cleave |n|n|cffffcc00Attacks land units.|r|n|n|cff99b4d1Limit 12 per gate."
+      "Value": "Frontline demon warrior."
     }
   ]
 }

--- a/mapdata/WarcraftLegacies/UnitData/Skin/n05F.json
+++ b/mapdata/WarcraftLegacies/UnitData/Skin/n05F.json
@@ -55,7 +55,7 @@
     {
       "Id": 1651864693,
       "Type": 3,
-      "Value": "Gateway attuned to the Voidwalkers of the Burning Crusade, summoning 1 every 30 seconds. |n|n|cfff5962dAbilities:|R Frost Attack|n|cfff5962dUpgrades Into:|R Nether Drake, Voidlord or Terrorguard Demon Gate|n|n|cff99b4d1Limit 12 per gate."
+      "Value": "Gateway attuned to the Voidwalkers of the Burning Crusade, summoning 1 every 30 seconds."
     },
     {
       "Id": 1953458293,

--- a/mapdata/WarcraftLegacies/UnitData/Skin/n05I.json
+++ b/mapdata/WarcraftLegacies/UnitData/Skin/n05I.json
@@ -55,7 +55,7 @@
     {
       "Id": 1651864693,
       "Type": 3,
-      "Value": "Gateway attuned to the packs of numerous Fel Hounds of the Burning Crusade, summoning 3 every 30 seconds. |n|n|cfff5962dAbilities:|R Mana Burn, Magic Resistance, Feedback|n|n|cff99b4d1Limit 12 per gate."
+      "Value": "Gateway attuned to the packs of numerous Fel Hounds of the Burning Crusade, summoning 3 every 30 seconds."
     },
     {
       "Id": 1953458293,

--- a/mapdata/WarcraftLegacies/UnitData/Skin/n05R.json
+++ b/mapdata/WarcraftLegacies/UnitData/Skin/n05R.json
@@ -55,7 +55,7 @@
     {
       "Id": 1651864693,
       "Type": 3,
-      "Value": "Gateway attuned to the Felguards of the Burning Crusade, summoning 2 every 60 seconds. |n|n|cfff5962dAbilities:|R Charge, Cleaving Attack, Critical Strike|n|n|cff99b4d1Limit 12 per gate."
+      "Value": "Gateway attuned to the Felguards of the Burning Crusade, summoning 2 every 60 seconds."
     },
     {
       "Id": 2020631157,

--- a/mapdata/WarcraftLegacies/UnitData/Skin/n06G.json
+++ b/mapdata/WarcraftLegacies/UnitData/Skin/n06G.json
@@ -55,7 +55,7 @@
     {
       "Id": 1651864693,
       "Type": 3,
-      "Value": "Gateway attuned to the void infused Nether Drakes of the Burning Crusade, summoning 1 every 60 seconds. |n|n|cfff5962dAbilities:|R Spell Resistance|n|n|cff99b4d1Limit 6 per gate."
+      "Value": "Gateway attuned to the void infused Nether Drakes of the Burning Crusade, summoning 1 every 60 seconds."
     },
     {
       "Id": 1953458293,

--- a/mapdata/WarcraftLegacies/UnitData/Skin/n06H.json
+++ b/mapdata/WarcraftLegacies/UnitData/Skin/n06H.json
@@ -59,7 +59,7 @@
     {
       "Id": 1651864693,
       "Type": 3,
-      "Value": "Gateway attuned to the Pit Fiends of the Burning Crusade, summoning 1 every 60 seconds. |n|n|cfff5962dAbility:|R Self-Bloodlust, Felsteel Plating|n|n|cff99b4d1Limit 6 per gate."
+      "Value": "Gateway attuned to the Pit Fiends of the Burning Crusade, summoning 1 every 60 seconds."
     },
     {
       "Id": 1953458293,

--- a/mapdata/WarcraftLegacies/UnitData/Skin/n070.json
+++ b/mapdata/WarcraftLegacies/UnitData/Skin/n070.json
@@ -48,7 +48,7 @@
     {
       "Id": 1651864693,
       "Type": 3,
-      "Value": "Swift nether drake summoned from the void.|n|cfff5962dAbilities:|R Spell Resistance.|n |r|n|cffffcc00Attacks land and air units.|r|n|n|cff99b4d1Limit 6 per gate."
+      "Value": "Swift nether drake summoned from the void."
     },
     {
       "Id": 1684960117,

--- a/mapdata/WarcraftLegacies/UnitData/Skin/n07M.json
+++ b/mapdata/WarcraftLegacies/UnitData/Skin/n07M.json
@@ -59,7 +59,7 @@
     {
       "Id": 1651864693,
       "Type": 3,
-      "Value": "Gateway attuned to the Voidlords of the Burning Crusade, summoning 1 every 60 seconds. |n|n|cfff5962dAbilities:|R Frost Attack, Soul Ritual|n|n|cff99b4d1Limit 6 per gate."
+      "Value": "Gateway attuned to the Voidlords of the Burning Crusade, summoning 1 every 60 seconds."
     },
     {
       "Id": 1953458293,

--- a/mapdata/WarcraftLegacies/UnitData/Skin/n07O.json
+++ b/mapdata/WarcraftLegacies/UnitData/Skin/n07O.json
@@ -55,7 +55,7 @@
     {
       "Id": 1651864693,
       "Type": 3,
-      "Value": "Gateway attuned to the Terrorguards of the Burning Crusade, summoning 1 every 90 seconds. |n|n|cfff5962dAbilities:|R True Sight, Resistant Skin|n|n|cff99b4d1Limit 6 per gate."
+      "Value": "Gateway attuned to the Terrorguards of the Burning Crusade, summoning 1 every 90 seconds."
     },
     {
       "Id": 2020631157,

--- a/mapdata/WarcraftLegacies/UnitData/Skin/n088.json
+++ b/mapdata/WarcraftLegacies/UnitData/Skin/n088.json
@@ -45,7 +45,7 @@
     {
       "Id": 1651864693,
       "Type": 3,
-      "Value": "Armored demon and darkening devastator of foes.|n|cfff5962dAbilities:|R Nether Explosions, Devour Magic, Frost Attack, Shadow Vault |n|n|cffffcc00Attacks land and air units.|r|n|n|cff99b4d1Limit 6 per gate."
+      "Value": "Armored demon and darkening devastator of foes."
     },
     {
       "Id": 1651270517,

--- a/mapdata/WarcraftLegacies/UnitData/Skin/nbwm.json
+++ b/mapdata/WarcraftLegacies/UnitData/Skin/nbwm.json
@@ -41,11 +41,6 @@
       "Id": 1885959285,
       "Type": 3,
       "Value": "Train Nefarian"
-    },
-    {
-      "Id": 1651864693,
-      "Type": 3,
-      "Value": "|cfff5962dAbilities:|R Breath of Fire, Devour, Searing Breath, Resistant Skin"
     }
   ]
 }

--- a/mapdata/WarcraftLegacies/UnitData/Skin/nmsc.json
+++ b/mapdata/WarcraftLegacies/UnitData/Skin/nmsc.json
@@ -71,7 +71,7 @@
     {
       "Id": 1651864693,
       "Type": 3,
-      "Value": "Secondary spellcaster, adept at weakening enemy armies and mass healing. |n|n|cffffcc00Attacks land and air units.|r"
+      "Value": "Secondary spellcaster, adept at weakening enemy armies and mass healing."
     }
   ]
 }

--- a/mapdata/WarcraftLegacies/UnitData/Skin/o014.json
+++ b/mapdata/WarcraftLegacies/UnitData/Skin/o014.json
@@ -86,7 +86,7 @@
     {
       "Id": 1651864693,
       "Type": 3,
-      "Value": "Winged demon-cousin of the Doomguard, and bringer of shadow and misery.|n|cfff5962dAbilities:|R Consume, Nether\u0027s Eye, Living Missile, Resistant Skin, True Sight|n|r|n|cffffcc00Attacks land and air units.|r|n|n|cff99b4d1Limit 6 per gate."
+      "Value": "Winged demon-cousin of the Doomguard, and bringer of shadow and misery."
     },
     {
       "Id": 1684960117,

--- a/mapdata/WarcraftLegacies/UnitData/Skin/o015.json
+++ b/mapdata/WarcraftLegacies/UnitData/Skin/o015.json
@@ -79,7 +79,7 @@
     {
       "Id": 1651864693,
       "Type": 3,
-      "Value": "Servants for the Pit Lords of the Legion, they aspire to rise and conquer for favor.|n|cfff5962dAbilities:|R Felsteel Plating, Frenzy|n|r|n|cffffcc00Attacks land units.|r|n|n|cff99b4d1Limit 6 per gate."
+      "Value": "Servants for the Pit Lords of the Legion, they aspire to rise and conquer for favor."
     },
     {
       "Id": 1684960117,

--- a/mapdata/WarcraftLegacies/UnitData/Skin/oshm.json
+++ b/mapdata/WarcraftLegacies/UnitData/Skin/oshm.json
@@ -22,7 +22,7 @@
     {
       "Id": 1651864693,
       "Type": 3,
-      "Value": "Primary spellcaster, adept at supporting frontline units. |n|n|cffffcc00Attacks land and air units.|r"
+      "Value": "Primary spellcaster, adept at supporting frontline units."
     }
   ]
 }


### PR DESCRIPTION
Removes a bunch of unit tooltip text that is meant to be autogenerated, such as information about what types of units a unit can attack.
Note that the Demon Gate information is _not_ fully autogenerated, so this represents a reduction to the information available on Demon Gate tooltips... but that barely matters because it's not accurate anyway. We can autogenerate it if we ever revisit Demon Gates.

Contributes to #3411 because it fixes an issue with Shadowcaster having two "attacks land and air units" tooltips.