### PR TITLE
Move Titanforging mechanic from MacroTools to WarcraftLegacies.Source

### DIFF
--- a/src/MacroTools/ArtifactSystem/Artifact.cs
+++ b/src/MacroTools/ArtifactSystem/Artifact.cs
@@ -12,7 +12,6 @@ public sealed class Artifact
 {
   private ArtifactLocationType _locationType;
   private unit? _owningUnit;
-  private int _titanforgedAbility = FourCC("A0VJ");
 
   /// <summary>
   ///   Initializes a new instance of the <see cref="Artifact" /> class.
@@ -39,19 +38,6 @@ public sealed class Artifact
   ///   The real <see cref="item" /> that the <see cref="Artifact" /> is representing.
   /// </summary>
   public item Item { get; }
-
-  /// <summary>
-  ///   The extra ability the Artifact gains when it's Titanforged.
-  /// </summary>
-  public int TitanforgedAbility
-  {
-    set => _titanforgedAbility = value;
-  }
-
-  /// <summary>
-  ///   Whether or not the Artifact has gained its bonus ability.
-  /// </summary>
-  public bool Titanforged { get; private set; }
 
   /// <summary>
   ///   Describes the kind of location that the <see cref="Artifact" /> is in.
@@ -118,22 +104,6 @@ public sealed class Artifact
   ///   Any Artifact changes its <see cref="ArtifactLocationType" />.
   /// </summary>
   public event EventHandler<Artifact>? StatusChanged;
-
-  /// <summary>
-  ///   Grant the Artifact a predefined bonus ability.
-  /// </summary>
-  public void Titanforge()
-  {
-    if (Titanforged)
-    {
-      return;
-    }
-
-    Titanforged = true;
-    Item.AddAbility(_titanforgedAbility);
-    Item.ExtendedDescription = $"{Item.ExtendedDescription}|n|n|cff800000Titanforged|r|n{BlzGetAbilityExtendedTooltip(_titanforgedAbility, 0)}";
-    Item.Description = $"{Item.Description}|n|cff800000Titanforged|r";
-  }
 
   /// <summary>
   ///   Pings the <see cref="Artifact" /> on the minimap for the given player.

--- a/src/WarcraftLegacies.Source/Quests/BlackEmpire/QuestBladeoftheBlackEmpire.cs
+++ b/src/WarcraftLegacies.Source/Quests/BlackEmpire/QuestBladeoftheBlackEmpire.cs
@@ -33,10 +33,7 @@ public sealed class QuestBladeoftheBlackEmpire : QuestData
 
   protected override void OnComplete(Faction whichFaction)
   {
-    var xalatath = new Artifact(item.Create(ITEM_I015_XAL_ATATH_BLADE_OF_THE_BLACK_EMPIRE, -3986, 2100))
-    {
-      TitanforgedAbility = ABILITY_A0VM_TITANFORGED_9_STRENGTH
-    };
+    var xalatath = new Artifact(item.Create(ITEM_I015_XAL_ATATH_BLADE_OF_THE_BLACK_EMPIRE, -3986, 2100));
     ArtifactManager.Register(xalatath);
 
     _anyUnitInRect.CompletingUnit?.AddItemSafe(xalatath.Item);

--- a/src/WarcraftLegacies.Source/Quests/QuestZinrokhAssembly.cs
+++ b/src/WarcraftLegacies.Source/Quests/QuestZinrokhAssembly.cs
@@ -49,10 +49,7 @@ public sealed class QuestZinrokhAssembly : QuestData
       ArtifactManager.Destroy(artifact);
     }
 
-    var zinrokh = new Artifact(item.Create(ITEM_I016_ZIN_ROKH_DESTROYER_OF_WORLDS, 0, 0))
-    {
-      TitanforgedAbility = ABILITY_A0VM_TITANFORGED_9_STRENGTH
-    };
+    var zinrokh = new Artifact(item.Create(ITEM_I016_ZIN_ROKH_DESTROYER_OF_WORLDS, 0, 0));
     ArtifactManager.Register(zinrokh);
     azureFragmentHolder?.AddItemSafe(zinrokh.Item);
   }

--- a/src/WarcraftLegacies.Source/Setup/ArtifactSetup.cs
+++ b/src/WarcraftLegacies.Source/Setup/ArtifactSetup.cs
@@ -58,11 +58,6 @@ public sealed class ArtifactSetup
   public Artifact EyeOfSargeras { get; }
 
   /// <summary>
-  /// Destroyer of Worlds.
-  /// </summary>
-  public Artifact ZinRokh { get; }
-
-  /// <summary>
   /// A fragment of Zin'rokh.
   /// </summary>
   public Artifact AzureFragment { get; }
@@ -128,11 +123,6 @@ public sealed class ArtifactSetup
 
     BookOfMedivh = new Artifact(item.Create(ITEM_I006_BOOK_OF_MEDIVH, DummyX, DummyY));
     ArtifactManager.Register(BookOfMedivh);
-
-    ZinRokh = new Artifact(item.Create(FourCC("I016"), DummyX, DummyY))
-    {
-      TitanforgedAbility = ABILITY_A0VM_TITANFORGED_9_STRENGTH
-    };
 
     BronzeFragment = new Artifact(item.Create(ITEM_I01M_BRONZE_FRAGMENT, DummyX, DummyY));
     preplacedUnitSystem.GetUnit(UNIT_O06Y_UKORZ_CREEP_ZUL_FARRAK).AddAbility(Artifact.ArtifactHolderAbilId);

--- a/src/WarcraftLegacies.Source/Setup/Spells/IronforgeSpellSetup.cs
+++ b/src/WarcraftLegacies.Source/Setup/Spells/IronforgeSpellSetup.cs
@@ -1,4 +1,5 @@
-﻿using MacroTools.Spells;
+﻿using System.Collections.Generic;
+using MacroTools.Spells;
 using MacroTools.UnitTypeTraits;
 using WarcraftLegacies.Source.Spells;
 using WarcraftLegacies.Source.UnitTypeTraits;
@@ -12,7 +13,16 @@ public static class IronforgeSpellSetup
   /// </summary>
   public static void Setup()
   {
-    SpellRegistry.Register(new TitanForgeArtifact(ABILITY_A0T3_TITANFORGE_ARTIFACT_IRONFORGE, 0));
+    SpellRegistry.Register(new TitanForgeArtifact(ABILITY_A0T3_TITANFORGE_ARTIFACT_IRONFORGE)
+    {
+      DefaultTitanforgedAbility = FourCC("A0VJ"),
+      UniqueTitanforgedAbilitiesByItemTypeId = new Dictionary<int, int>
+      {
+        { ITEM_I016_ZIN_ROKH_DESTROYER_OF_WORLDS, ABILITY_A0VM_TITANFORGED_9_STRENGTH },
+        { ITEM_I015_XAL_ATATH_BLADE_OF_THE_BLACK_EMPIRE, ABILITY_A0VM_TITANFORGED_9_STRENGTH }
+      },
+      GoldCost = 25
+    });
 
     UnitTypeTraitRegistry.Register(new SpellOnAttack(ABILITY_A10J_MASTER_OF_LIGHTNING_STORMRIDERS)
     {


### PR DESCRIPTION
The main purpose of this is actually to support the InaccessibleObjectCollection, which does not account for ability IDs only present in MacroTools. Rather than make it consider MacroTools, I'd rather just not mention Legacies-specific object IDs in there at all.