### PR TITLE
Reorganize Launcher.Commands folder

### DIFF
--- a/src/Launcher/CLI/Commands/MapCommand.cs
+++ b/src/Launcher/CLI/Commands/MapCommand.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.CommandLine;
+using Launcher.CLI.Contexts;
 
-namespace Launcher.Commands;
+namespace Launcher.CLI.Commands;
 
 internal sealed class MapCommand<T> : Command where T : MapCommandContext
 {

--- a/src/Launcher/CLI/Commands/MapCommandFactory.cs
+++ b/src/Launcher/CLI/Commands/MapCommandFactory.cs
@@ -1,13 +1,13 @@
 ﻿using System.CommandLine;
 using System.IO;
-using Launcher.Settings;
-using MapBuildCommand = Launcher.Commands.MapCommand<Launcher.Commands.MapBuildContext>;
-using MapGenerateCommand = Launcher.Commands.MapCommand<Launcher.Commands.MapGenerateContext>;
-using MapSerializeCommand = Launcher.Commands.MapCommand<Launcher.Commands.MapSerializationContext>;
+using Launcher.CLI.Contexts;
+using MapBuildCommand = Launcher.CLI.Commands.MapCommand<Launcher.CLI.Contexts.MapBuildContext>;
+using MapGenerateCommand = Launcher.CLI.Commands.MapCommand<Launcher.CLI.Contexts.MapGenerateContext>;
+using MapSerializeCommand = Launcher.CLI.Commands.MapCommand<Launcher.CLI.Contexts.MapSerializationContext>;
 
-namespace Launcher.Commands;
+namespace Launcher.CLI.Commands;
 
-internal static class MapCommandBuilder
+internal static class MapCommandFactory
 {
   public static Command Build()
   {

--- a/src/Launcher/CLI/Contexts/MapBuildContext.cs
+++ b/src/Launcher/CLI/Contexts/MapBuildContext.cs
@@ -2,7 +2,7 @@
 using AutoMapper;
 using Launcher.Services;
 
-namespace Launcher.Commands;
+namespace Launcher.CLI.Contexts;
 
 internal sealed class MapBuildContext : MapCommandContext
 {
@@ -40,4 +40,10 @@ internal sealed class MapBuildContext : MapCommandContext
         throw new ArgumentOutOfRangeException($"Unsupported output kind: {OutputKind}");
     }
   }
+}
+
+internal enum MapOutputKind
+{
+  Directory,
+  File
 }

--- a/src/Launcher/CLI/Contexts/MapCommandContext.cs
+++ b/src/Launcher/CLI/Contexts/MapCommandContext.cs
@@ -1,6 +1,6 @@
 ﻿using Launcher.Services;
 
-namespace Launcher.Commands;
+namespace Launcher.CLI.Contexts;
 
 internal abstract class MapCommandContext(string mapName)
 {

--- a/src/Launcher/CLI/Contexts/MapGenerateContext.cs
+++ b/src/Launcher/CLI/Contexts/MapGenerateContext.cs
@@ -1,7 +1,7 @@
 ﻿using AutoMapper;
 using Launcher.Services;
 
-namespace Launcher.Commands;
+namespace Launcher.CLI.Contexts;
 
 internal sealed class MapGenerateContext : MapCommandContext
 {

--- a/src/Launcher/CLI/Contexts/MapSerializationContext.cs
+++ b/src/Launcher/CLI/Contexts/MapSerializationContext.cs
@@ -1,7 +1,7 @@
 ﻿using AutoMapper;
 using Launcher.Services;
 
-namespace Launcher.Commands;
+namespace Launcher.CLI.Contexts;
 
 internal sealed class MapSerializationContext(string mapName) : MapCommandContext(mapName)
 {

--- a/src/Launcher/Commands/MapOutputKind.cs
+++ b/src/Launcher/Commands/MapOutputKind.cs
@@ -1,7 +1,0 @@
-﻿namespace Launcher.Commands;
-
-internal enum MapOutputKind
-{
-  Directory,
-  File
-}

--- a/src/Launcher/Program.cs
+++ b/src/Launcher/Program.cs
@@ -1,5 +1,5 @@
 ﻿using System.CommandLine;
-using Launcher.Commands;
+using Launcher.CLI.Commands;
 
 namespace Launcher;
 
@@ -16,19 +16,19 @@ internal static class Program
     [
       new Command("json-to-w3x")
       {
-        MapCommandBuilder.Build(),
-        MapCommandBuilder.Test(),
-        MapCommandBuilder.Publish()
+        MapCommandFactory.Build(),
+        MapCommandFactory.Test(),
+        MapCommandFactory.Publish()
       },
 
       new Command("w3x-to-json")
       {
-        MapCommandBuilder.Serialize()
+        MapCommandFactory.Serialize()
       },
 
       new Command("generate")
       {
-        MapCommandBuilder.Generate()
+        MapCommandFactory.Generate()
       }
     ];
   }


### PR DESCRIPTION
I didn't love the way I had organized the Commands folder, so I'm just moving some stuff around.
1. Renamed `Commands` to `CLI`
2. Added `Commands` subfolder, just contains the one command (but would logically contain any further ones)
3. Renamed `MapCommandBuilder` to `MapCommandFactory` (not a builder) and put it alongside `MapCommand`