### PR TITLE
Support W3XToMapData incremental exports

### DIFF
--- a/src/Launcher/CLI/Commands/MapCommand.cs
+++ b/src/Launcher/CLI/Commands/MapCommand.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.CommandLine;
 using Launcher.CLI.Contexts;
+using Launcher.Services;
 
 namespace Launcher.CLI.Commands;
 
@@ -15,15 +16,35 @@ internal sealed class MapCommand<T> : Command where T : MapCommandContext
       Description = "The directory containing the map."
     };
 
+    Option<IncludeFromMap> includeFromMapOption = new("--include")
+    {
+      Aliases = { "-i" },
+      Description = "A list of flags to indicate what should be included in map conversion.",
+      DefaultValueFactory = _ => IncludeFromMap.All
+    };
+
+    Option<bool> deleteDestinationOption = new("--delete-destination")
+    {
+      Aliases = { "-d" },
+      Description = "If true, the output directories or files will be deleted prior to map conversion. Defaults to true.",
+      DefaultValueFactory = _ => true
+    };
+
     Add(mapNameArg);
+    Add(includeFromMapOption);
+    Add(deleteDestinationOption);
 
     SetAction(result =>
     {
-      var ctx = CreateContext(result.GetValue(mapNameArg));
+      var includeFromMap = result.GetValue(includeFromMapOption);
+      var deleteDestination = result.GetValue(deleteDestinationOption);
+
+      var ctx = CreateContext(result.GetValue(mapNameArg), includeFromMap, deleteDestination);
       Configure?.Invoke(ctx);
       ctx.Execute();
     });
   }
 
-  private static T CreateContext(string mapName) => (T)Activator.CreateInstance(typeof(T), mapName);
+  private static T CreateContext(string mapName, IncludeFromMap include, bool deleteDestination) =>
+    (T)Activator.CreateInstance(typeof(T), mapName, include, deleteDestination);
 }

--- a/src/Launcher/CLI/Contexts/MapBuildContext.cs
+++ b/src/Launcher/CLI/Contexts/MapBuildContext.cs
@@ -9,7 +9,7 @@ internal sealed class MapBuildContext : MapCommandContext
 
   public MapOutputKind OutputKind { get; set; }
 
-  public MapBuildContext(string mapName) : base(mapName)
+  public MapBuildContext(string mapName, IncludeFromMap include, bool deleteDestination) : base(mapName, include, deleteDestination)
   {
     Builder = AdvancedMapBuilderOptions.Create(Paths);
   }

--- a/src/Launcher/CLI/Contexts/MapCommandContext.cs
+++ b/src/Launcher/CLI/Contexts/MapCommandContext.cs
@@ -1,8 +1,9 @@
 ﻿using Launcher.Paths;
+using Launcher.Services;
 
 namespace Launcher.CLI.Contexts;
 
-internal abstract class MapCommandContext(string mapName)
+internal abstract class MapCommandContext(string mapName, IncludeFromMap include, bool deleteDestination)
 {
   public string MapName { get; } = mapName;
   public SharedPathOptions Paths { get; } = SharedPathOptions.Create(mapName);

--- a/src/Launcher/CLI/Contexts/MapGenerateContext.cs
+++ b/src/Launcher/CLI/Contexts/MapGenerateContext.cs
@@ -8,7 +8,7 @@ internal sealed class MapGenerateContext : MapCommandContext
 
   public MapDataToMapConverterOptions SerializerOptions { get; }
 
-  public MapGenerateContext(string mapName) : base(mapName)
+  public MapGenerateContext(string mapName, IncludeFromMap include, bool deleteDestination) : base(mapName, include, deleteDestination)
   {
     GeneratorOptions = ConstantsGeneratorOptions.Create(Paths);
     SerializerOptions = MapDataToMapConverterOptions.Create(Paths);

--- a/src/Launcher/CLI/Contexts/MapSerializationContext.cs
+++ b/src/Launcher/CLI/Contexts/MapSerializationContext.cs
@@ -6,14 +6,16 @@ internal sealed class MapSerializationContext : MapCommandContext
 {
   public W3XToMapDataConverterOptions Options { get; }
 
-  public MapSerializationContext(string mapName) : base(mapName)
+  public MapSerializationContext(string mapName, IncludeFromMap include, bool deleteDestination) : base(mapName, include, deleteDestination)
   {
     Options = W3XToMapDataConverterOptions.Create(Paths);
+    Options.IncludeFromMap = include;
+    Options.DeleteDestinations = deleteDestination;
   }
 
   public override void Execute()
   {
-    var converter = new W3XToMapDataConverter(W3XToMapDataConverterOptions.Create(Paths));
+    var converter = new W3XToMapDataConverter(Options);
     converter.Convert(Paths.W3XFolderPath);
   }
 }

--- a/src/Launcher/Paths/MapDataPathOptions.cs
+++ b/src/Launcher/Paths/MapDataPathOptions.cs
@@ -1,4 +1,8 @@
-﻿namespace Launcher.Paths;
+﻿using System;
+using System.Collections.Generic;
+using Launcher.Services;
+
+namespace Launcher.Paths;
 
 public sealed class MapDataPathOptions
 {
@@ -40,7 +44,60 @@ public sealed class MapDataPathOptions
 
   public required string MinimapPath { get; init; }
 
+  public required string GameplayConstantsPath { get; init; }
+
   public required string GameInterfacePath { get; init; }
 
-  public required string SkinPath { get; init; }
+  /// <summary>
+  /// Returns all map file paths that match any of the flags specified in <see cref="IncludeFromMap"/>.
+  /// </summary>
+  public IEnumerable<string> GetPathsFromIncludedFiles(IncludeFromMap include)
+  {
+    if (include.HasFlag(IncludeFromMap.All))
+    {
+      yield return RootPath;
+      yield break;
+    }
+
+    foreach (var flag in Enum.GetValues<IncludeFromMap>())
+    {
+      if (flag == IncludeFromMap.All || !include.HasFlag(flag))
+      {
+        continue;
+      }
+
+      var path = flag switch
+      {
+        IncludeFromMap.Sounds => SoundsPath,
+        IncludeFromMap.Environment => EnvironmentPath,
+        IncludeFromMap.PathingMap => PathingMapPath,
+        IncludeFromMap.PreviewIcons => PreviewIconsPath,
+        IncludeFromMap.ShadowMap => ShadowMapPath,
+        IncludeFromMap.Minimap => MinimapPath,
+        IncludeFromMap.Regions => RegionsPath,
+        IncludeFromMap.Imports => ImportsPath,
+        IncludeFromMap.Info => InfoPath,
+        IncludeFromMap.GameplayConstants => GameplayConstantsPath,
+        IncludeFromMap.GameInterface => GameInterfacePath,
+
+        IncludeFromMap.AbilityData => AbilityDataPath,
+        IncludeFromMap.BuffData => BuffDataPath,
+        IncludeFromMap.DestructableData => DestructableDataPath,
+        IncludeFromMap.DoodadData => DoodadDataPath,
+        IncludeFromMap.ItemData => ItemDataPath,
+        IncludeFromMap.UnitData => UnitDataPath,
+        IncludeFromMap.UpgradeData => UpgradeDataPath,
+
+        IncludeFromMap.Doodads => DoodadsPath,
+        IncludeFromMap.Units => UnitsPath,
+
+        _ => null
+      };
+
+      if (path is not null)
+      {
+        yield return path;
+      }
+    }
+  }
 }

--- a/src/Launcher/Paths/SharedPathOptions.cs
+++ b/src/Launcher/Paths/SharedPathOptions.cs
@@ -44,8 +44,8 @@ public sealed class SharedPathOptions
         PreviewIconsPath = Path.Combine(mapDataRootPath, PathConventions.MapData.PreviewIcons),
         ShadowMapPath = Path.Combine(mapDataRootPath, PathConventions.MapData.ShadowMap),
         MinimapPath = Path.Combine(mapDataRootPath, PathConventions.MapData.Minimap),
-        GameInterfacePath = Path.Combine(mapDataRootPath, PathConventions.MapData.GameplayConstants),
-        SkinPath = Path.Combine(mapDataRootPath, PathConventions.MapData.GameInterface)
+        GameplayConstantsPath = Path.Combine(mapDataRootPath, PathConventions.MapData.GameplayConstants),
+        GameInterfacePath = Path.Combine(mapDataRootPath, PathConventions.MapData.GameInterface)
       }
     };
     return options;

--- a/src/Launcher/Properties/launchSettings.json
+++ b/src/Launcher/Properties/launchSettings.json
@@ -12,6 +12,10 @@
       "commandName": "Project",
       "commandLineArgs": "Launcher w3x-to-json serialize WarcraftLegacies"
     },
+    "Convert W3X to MapData (Objects Only)": {
+      "commandName": "Project",
+      "commandLineArgs": "Launcher w3x-to-json serialize WarcraftLegacies --include ObjectData"
+    },
     "Convert MapData to W3X": {
       "commandName": "Project",
       "commandLineArgs": "Launcher json-to-w3x build WarcraftLegacies"

--- a/src/Launcher/Services/IncludeFromMap.cs
+++ b/src/Launcher/Services/IncludeFromMap.cs
@@ -1,0 +1,176 @@
+﻿using System;
+using War3Net.Build;
+
+namespace Launcher.Services;
+
+/// <summary>
+/// Flags indicating which files and folders should be retained in a W3X map conversion.
+/// </summary>
+[Flags]
+public enum IncludeFromMap
+{
+  Sounds = 1 << 0,
+  Environment = 1 << 1,
+  PathingMap = 1 << 2,
+  PreviewIcons = 1 << 3,
+  Regions = 1 << 4,
+  ShadowMap = 1 << 5,
+  Minimap = 1 << 6,
+  Imports = 1 << 7,
+  Info = 1 << 8,
+
+  AbilityData = 1 << 9,
+  BuffData = 1 << 10,
+  DestructableData = 1 << 11,
+  DoodadData = 1 << 12,
+  ItemData = 1 << 13,
+  UnitData = 1 << 14,
+  UpgradeData = 1 << 15,
+
+  GameplayConstants = 1 << 16,
+  GameInterface = 1 << 17,
+  Script = 1 << 18,
+
+  Doodads = 1 << 19,
+  Units = 1 << 20,
+
+  ObjectData =
+    AbilityData |
+    BuffData |
+    DestructableData |
+    DoodadData |
+    ItemData |
+    UnitData |
+    UpgradeData,
+
+  Terrain =
+    Environment |
+    PathingMap |
+    PreviewIcons |
+    ShadowMap |
+    Doodads,
+
+  All =
+    Sounds |
+    Terrain |
+    Regions |
+    ShadowMap |
+    Minimap |
+    Imports |
+    Info |
+    ObjectData |
+    GameplayConstants |
+    GameInterface |
+    Script |
+    Units,
+}
+
+public static class IncludeFromMapExtensions
+{
+  /// <summary>
+  /// Converts <see cref="IncludeFromMap"/> flags to War3Net-based <see cref="MapFiles"/> flags, which can be used
+  /// to determine which files are incorporated from a W3X to a new <see cref="Map"/>.
+  /// <remarks>Not all <see cref="IncludeFromMap"/> flags have a corresponding <see cref="MapFiles"/> flag.</remarks>
+  /// </summary>
+  public static MapFiles ToWar3NetMapFiles(this IncludeFromMap include)
+  {
+    MapFiles result = 0;
+
+    if (include.HasFlag(IncludeFromMap.Sounds))
+    {
+      result |= MapFiles.Sounds;
+    }
+
+    if (include.HasFlag(IncludeFromMap.Environment))
+    {
+      result |= MapFiles.Environment;
+    }
+
+    if (include.HasFlag(IncludeFromMap.PathingMap))
+    {
+      result |= MapFiles.PathingMap;
+    }
+
+    if (include.HasFlag(IncludeFromMap.PreviewIcons))
+    {
+      result |= MapFiles.PreviewIcons;
+    }
+
+    if (include.HasFlag(IncludeFromMap.Regions))
+    {
+      result |= MapFiles.Regions;
+    }
+
+    if (include.HasFlag(IncludeFromMap.ShadowMap))
+    {
+      result |= MapFiles.ShadowMap;
+    }
+
+    if (include.HasFlag(IncludeFromMap.Imports))
+    {
+      result |= MapFiles.ImportedFiles;
+    }
+
+    if (include.HasFlag(IncludeFromMap.Info))
+    {
+      result |= MapFiles.Info;
+    }
+
+    if (include.HasFlag(IncludeFromMap.AbilityData))
+    {
+      result |= MapFiles.AbilityObjectData;
+    }
+
+    if (include.HasFlag(IncludeFromMap.BuffData))
+    {
+      result |= MapFiles.BuffObjectData;
+    }
+
+    if (include.HasFlag(IncludeFromMap.DestructableData))
+    {
+      result |= MapFiles.DestructableObjectData;
+    }
+
+    if (include.HasFlag(IncludeFromMap.DoodadData))
+    {
+      result |= MapFiles.DoodadObjectData;
+    }
+
+    if (include.HasFlag(IncludeFromMap.ItemData))
+    {
+      result |= MapFiles.ItemObjectData;
+    }
+
+    if (include.HasFlag(IncludeFromMap.UnitData))
+    {
+      result |= MapFiles.UnitObjectData;
+    }
+
+    if (include.HasFlag(IncludeFromMap.UpgradeData))
+    {
+      result |= MapFiles.UpgradeObjectData;
+    }
+
+    if (include.HasFlag(IncludeFromMap.GameplayConstants))
+    {
+      result |= MapFiles.CustomTextTriggers;
+    }
+
+    if (include.HasFlag(IncludeFromMap.Script))
+    {
+      result |= MapFiles.Script;
+    }
+
+    if (include.HasFlag(IncludeFromMap.Doodads))
+    {
+      result |= MapFiles.Doodads;
+    }
+
+    if (include.HasFlag(IncludeFromMap.Units))
+    {
+      result |= MapFiles.Units;
+    }
+
+    return result;
+  }
+}

--- a/src/Launcher/Services/MapDataToMapConverter.cs
+++ b/src/Launcher/Services/MapDataToMapConverter.cs
@@ -298,6 +298,12 @@ public sealed class MapDataToMapConverter(MapDataToMapConverterOptions options)
       });
     }
 
+    additionalFiles.Add(new PathData
+    {
+      AbsolutePath = Path.Combine(options.MapDataPaths.RootPath, MapData.GameInterface),
+      RelativePath = MapData.GameInterface
+    });
+
     return additionalFiles;
   }
 

--- a/src/Launcher/Services/MapDataToMapConverterOptions.cs
+++ b/src/Launcher/Services/MapDataToMapConverterOptions.cs
@@ -29,8 +29,8 @@ public sealed class MapDataToMapConverterOptions
         PreviewIconsPath = sharedPathOptions.MapDataPathOptions.PreviewIconsPath,
         ShadowMapPath = sharedPathOptions.MapDataPathOptions.ShadowMapPath,
         MinimapPath = sharedPathOptions.MapDataPathOptions.MinimapPath,
-        GameInterfacePath = sharedPathOptions.MapDataPathOptions.GameInterfacePath,
-        SkinPath = sharedPathOptions.MapDataPathOptions.SkinPath
+        GameplayConstantsPath = sharedPathOptions.MapDataPathOptions.GameplayConstantsPath,
+        GameInterfacePath = sharedPathOptions.MapDataPathOptions.GameInterfacePath
       }
     };
   }

--- a/src/Launcher/Services/W3XToMapDataConverter.cs
+++ b/src/Launcher/Services/W3XToMapDataConverter.cs
@@ -28,7 +28,7 @@ public sealed class W3XToMapDataConverter(W3XToMapDataConverterOptions options)
   /// </summary>
   public void Convert(string baseMapPath)
   {
-    var map = Map.Open(baseMapPath);
+    var map = Map.Open(baseMapPath, options.IncludeFromMap.ToWar3NetMapFiles());
     map.MergeObjectData();
     SerializeAndWriteMapData(map);
 
@@ -39,6 +39,11 @@ public sealed class W3XToMapDataConverter(W3XToMapDataConverterOptions options)
 
   private void SerializeAndWriteMapData(Map map)
   {
+    if (options.DeleteDestinations)
+    {
+      DeleteDestinationData();
+    }
+
     if (map.Doodads != null)
     {
       SerializeAndWriteDoodads(map.Doodads, options.MapDataPaths.DoodadsPath);
@@ -119,6 +124,24 @@ public sealed class W3XToMapDataConverter(W3XToMapDataConverterOptions options)
     if (map.UpgradeObjectData != null)
     {
       SerializeAndWriteUpgradeData(map.UpgradeObjectData);
+    }
+  }
+
+  private void DeleteDestinationData()
+  {
+    foreach (var path in options.MapDataPaths.GetPathsFromIncludedFiles(options.IncludeFromMap))
+    {
+      if (Directory.Exists(path))
+      {
+        Directory.Delete(path, true);
+      }
+      else
+      {
+        if (File.Exists(path))
+        {
+          File.Delete(path);
+        }
+      }
     }
   }
 

--- a/src/Launcher/Services/W3XToMapDataConverterOptions.cs
+++ b/src/Launcher/Services/W3XToMapDataConverterOptions.cs
@@ -29,11 +29,22 @@ public sealed class W3XToMapDataConverterOptions
         PreviewIconsPath = sharedPathOptions.MapDataPathOptions.PreviewIconsPath,
         ShadowMapPath = sharedPathOptions.MapDataPathOptions.ShadowMapPath,
         MinimapPath = sharedPathOptions.MapDataPathOptions.MinimapPath,
-        GameInterfacePath = sharedPathOptions.MapDataPathOptions.GameInterfacePath,
-        SkinPath = sharedPathOptions.MapDataPathOptions.SkinPath
-      }
+        GameplayConstantsPath = sharedPathOptions.MapDataPathOptions.GameplayConstantsPath,
+        GameInterfacePath = sharedPathOptions.MapDataPathOptions.GameInterfacePath
+      },
+      IncludeFromMap = IncludeFromMap.All
     };
   }
 
   public required MapDataPathOptions MapDataPaths { get; init; }
+
+  /// <summary>
+  /// Flags indicating which files and folders should be retrieved from the input map and included in the MapData result.
+  /// </summary>
+  public required IncludeFromMap IncludeFromMap { get; set; }
+
+  /// <summary>
+  /// If true, MapData destination folders will be deleted prior to conversion.
+  /// </summary>
+  public bool DeleteDestinations { get; set; }
 }


### PR DESCRIPTION
This PR adds support for doing incremental MapData exports. W3XToMapDataConverter can take in a new `IncludeInMap` flag, which is used to:
- Determine which paths to delete prior to performing an export
- Indicate to `Map.Open` which files it should absorb from the provided W3X file

The `w3x-to-json serialize` command has been updated to support passing through these flags, defaulting to `All`. There are are two utility flags, `ObjectData` and `Terrain`, that encompass a number of other flags. Finally, a new default has been added to `launchSettings.json` for exporting only object data, since that is a very common editor need.

These changes will help speed up development by making exports faster, as long as the developer is willing to use the command line and has an understanding of what they need to export.