### PR TITLE
ci: bump `actions/checkout` to v6

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -13,7 +13,7 @@ jobs:
     Developer-CI:
         runs-on: ubuntu-latest
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v6
             -   name: Setup .NET
                 uses: actions/setup-dotnet@v1
                 with:
@@ -38,7 +38,7 @@ jobs:
     Integrity-Check:
         runs-on: windows-latest
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v6
             -   name: Setup .NET
                 uses: actions/setup-dotnet@v1
                 with:

--- a/.github/workflows/github-beta-releases-to-discord.yml
+++ b/.github/workflows/github-beta-releases-to-discord.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Github Releases To Discord
         uses: SethCohen/github-releases-to-discord@v1.13.1
         with:

--- a/.github/workflows/github-releases-to-discord.yml
+++ b/.github/workflows/github-releases-to-discord.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Github Releases To Discord
         uses: SethCohen/github-releases-to-discord@v1.13.1
         with:


### PR DESCRIPTION
`actions/checkout@v3` is deprecated and uses a deprecated NodeJS runtime