### PR TITLE
Support MapDataToW3X incremental exports

### DIFF
--- a/src/Warcraft.Cartographer/Deserialization/AdvancedMapBuilder.cs
+++ b/src/Warcraft.Cartographer/Deserialization/AdvancedMapBuilder.cs
@@ -53,13 +53,9 @@ public sealed class AdvancedMapBuilder(AdvancedMapBuilderOptions options)
   {
     SupplementMap(map);
 
-    if (options.ShouldBackup && Directory.Exists(options.W3XFolderPath))
+    if (options.DeleteDestination)
     {
-      if (options.ShouldBackup)
-      {
-        BackupFiles(options.BackupPath, options.W3XFolderPath);
-      }
-      Directory.Delete(options.W3XFolderPath, true);
+      DeleteOutputDirectory();
     }
 
     map.BuildDirectory(options.W3XFolderPath, additionalFiles);
@@ -178,6 +174,16 @@ public sealed class AdvancedMapBuilder(AdvancedMapBuilderOptions options)
     // Update war3map.lua so you can inspect the generated Lua code easily
     Directory.CreateDirectory(options.ScriptArtifactPath);
     File.WriteAllText(Path.Combine(options.ScriptArtifactPath, PathConventions.MapData.Script), map.Script);
+  }
+
+  private void DeleteOutputDirectory()
+  {
+    if (options.ShouldBackup && Directory.Exists(options.W3XFolderPath))
+    {
+      BackupFiles(options.BackupPath, options.W3XFolderPath);
+    }
+
+    Directory.Delete(options.W3XFolderPath, true);
   }
 
   private static void BackupFiles(string backupDirectory, string mapPath)

--- a/src/Warcraft.Cartographer/Deserialization/AdvancedMapBuilderOptions.cs
+++ b/src/Warcraft.Cartographer/Deserialization/AdvancedMapBuilderOptions.cs
@@ -75,4 +75,9 @@ public sealed class AdvancedMapBuilderOptions
   /// If <see cref="ShouldMigrate"/> is true, these migrations are applied to the map during build.
   /// </summary>
   public IEnumerable<IMapMigration> MapMigrations { get; set; } = [];
+
+  /// <summary>
+  /// If true, relevant destination folders will be deleted before exporting W3X folders.
+  /// </summary>
+  public bool DeleteDestination { get; set; }
 }

--- a/src/Warcraft.Cartographer/Deserialization/IncludeFromMap.cs
+++ b/src/Warcraft.Cartographer/Deserialization/IncludeFromMap.cs
@@ -64,6 +64,19 @@ public enum IncludeFromMap
     GameplayConstants |
     GameInterface |
     Script |
+    Units,
+
+  AllExceptScript =
+    Sounds |
+    Terrain |
+    Regions |
+    ShadowMap |
+    Minimap |
+    Imports |
+    Info |
+    ObjectData |
+    GameplayConstants |
+    GameInterface |
     Units
 }
 

--- a/src/Warcraft.Cartographer/Deserialization/MapDataToMapConverterOptions.cs
+++ b/src/Warcraft.Cartographer/Deserialization/MapDataToMapConverterOptions.cs
@@ -5,4 +5,6 @@ namespace Warcraft.Cartographer.Deserialization;
 public sealed class MapDataToMapConverterOptions
 {
   public required MapDataPathOptions MapDataPaths { get; init; }
+
+  public required IncludeFromMap IncludeFromMap { get; set; }
 }

--- a/src/WarcraftLegacies.CLI/Commands/MapCommand.cs
+++ b/src/WarcraftLegacies.CLI/Commands/MapCommand.cs
@@ -20,7 +20,7 @@ internal sealed class MapCommand<T> : Command where T : MapCommandContext
     {
       Aliases = { "-i" },
       Description = "A list of flags to indicate what should be included in map conversion.",
-      DefaultValueFactory = _ => IncludeFromMap.All
+      DefaultValueFactory = _ => IncludeFromMap.AllExceptScript
     };
 
     Option<bool> deleteDestinationOption = new("--delete-destination")

--- a/src/WarcraftLegacies.CLI/Commands/MapCommandFactory.cs
+++ b/src/WarcraftLegacies.CLI/Commands/MapCommandFactory.cs
@@ -17,7 +17,7 @@ internal static class MapCommandFactory
       Configure = ctx =>
       {
         ctx.OutputKind = MapOutputKind.Directory;
-        ctx.Builder.ShouldBackup = true;
+        ctx.AdvancedMapBuilderOptions.ShouldBackup = true;
       }
     };
   }
@@ -29,11 +29,11 @@ internal static class MapCommandFactory
       Configure = ctx =>
       {
         ctx.OutputKind = MapOutputKind.Directory;
-        ctx.Builder.ShouldLaunch = true;
-        ctx.Builder.ShouldTranspile = true;
-        ctx.Builder.ShouldMigrate = true;
-        ctx.Builder.W3XFolderPath = Path.Combine(ctx.Paths.ScriptArtifactPath, $"{ctx.MapName}.w3x");
-        ctx.Builder.TestingPlayerSlot = AppSettings.Current.CompilerSettings.TestingPlayerSlot;
+        ctx.AdvancedMapBuilderOptions.ShouldLaunch = true;
+        ctx.AdvancedMapBuilderOptions.ShouldTranspile = true;
+        ctx.AdvancedMapBuilderOptions.ShouldMigrate = true;
+        ctx.AdvancedMapBuilderOptions.W3XFolderPath = Path.Combine(ctx.Paths.ScriptArtifactPath, $"{ctx.MapName}.w3x");
+        ctx.AdvancedMapBuilderOptions.TestingPlayerSlot = AppSettings.Current.CompilerSettings.TestingPlayerSlot;
       }
     };
   }
@@ -45,9 +45,9 @@ internal static class MapCommandFactory
       Configure = ctx =>
       {
         ctx.OutputKind = MapOutputKind.File;
-        ctx.Builder.ShouldMigrate = true;
-        ctx.Builder.ShouldSetVersion = true;
-        ctx.Builder.ShouldTranspile = true;
+        ctx.AdvancedMapBuilderOptions.ShouldMigrate = true;
+        ctx.AdvancedMapBuilderOptions.ShouldSetVersion = true;
+        ctx.AdvancedMapBuilderOptions.ShouldTranspile = true;
       }
     };
   }

--- a/src/WarcraftLegacies.CLI/Contexts/MapBuildContext.cs
+++ b/src/WarcraftLegacies.CLI/Contexts/MapBuildContext.cs
@@ -7,20 +7,27 @@ namespace WarcraftLegacies.CLI.Contexts;
 
 internal sealed class MapBuildContext : MapCommandContext
 {
-  public AdvancedMapBuilderOptions Builder { get; }
+  public AdvancedMapBuilderOptions AdvancedMapBuilderOptions { get; }
+
+  public MapDataToMapConverterOptions MapConverterOptions { get; }
 
   public MapOutputKind OutputKind { get; set; }
 
   public MapBuildContext(string mapName, IncludeFromMap include, bool deleteDestination) : base(mapName, include, deleteDestination)
   {
-    Builder = DefaultOptionsFactory.CreateAdvancedMapBuilderOptions(Paths);
-    Builder.MapMigrations = MapMigrationProvider.GetMapMigrations();
+    AdvancedMapBuilderOptions = DefaultOptionsFactory.CreateAdvancedMapBuilderOptions(Paths);
+    AdvancedMapBuilderOptions.MapMigrations = MapMigrationProvider.GetMapMigrations();
+    AdvancedMapBuilderOptions.DeleteDestination = deleteDestination;
+    AdvancedMapBuilderOptions.ShouldTranspile = include.HasFlag(IncludeFromMap.Script);
+
+    MapConverterOptions = DefaultOptionsFactory.CreateMapDataToMapConverterOptions(Paths);
+    MapConverterOptions.IncludeFromMap = include;
   }
 
   public override void Execute()
   {
-    var converter = new MapDataToMapConverter(DefaultOptionsFactory.CreateMapDataToMapConverterOptions(Paths));
-    var builder = new AdvancedMapBuilder(Builder);
+    var converter = new MapDataToMapConverter(MapConverterOptions);
+    var builder = new AdvancedMapBuilder(AdvancedMapBuilderOptions);
 
     switch (OutputKind)
     {

--- a/src/WarcraftLegacies.CLI/Properties/launchSettings.json
+++ b/src/WarcraftLegacies.CLI/Properties/launchSettings.json
@@ -19,6 +19,10 @@
     "Generate Constants": {
       "commandName": "Project",
       "commandLineArgs": "WarcraftLegacies.CLI generate constants WarcraftLegacies"
+    },
+    "Convert C# to Lua": {
+      "commandName": "Project",
+      "commandLineArgs": "WarcraftLegacies.CLI json-to-w3x build WarcraftLegacies -i Script -d false"
     }
   }
 }

--- a/src/WarcraftLegacies.CLI/Settings/DefaultOptionsFactory.cs
+++ b/src/WarcraftLegacies.CLI/Settings/DefaultOptionsFactory.cs
@@ -108,7 +108,8 @@ public static class DefaultOptionsFactory
         MinimapPath = sharedPathOptions.MapDataPathOptions.MinimapPath,
         GameplayConstantsPath = sharedPathOptions.MapDataPathOptions.GameplayConstantsPath,
         GameInterfacePath = sharedPathOptions.MapDataPathOptions.GameInterfacePath
-      }
+      },
+      IncludeFromMap = IncludeFromMap.All
     };
   }
 }


### PR DESCRIPTION
In the opposite direction to #3546, this PR allows developers to convert only parts of MapData and transfer them to the output `maps` directory. This defaults to exporting everything _except_ the script file, since the default conversion exists to produce a map for editing in the World Editor. I have also included a new launch setting to demonstrate exporting the script file by itself.