### PR TITLE
Illidan abandons the Broken Isles when he first travels to Outland

### DIFF
--- a/src/WarcraftLegacies.Source/Factions/Illidari.cs
+++ b/src/WarcraftLegacies.Source/Factions/Illidari.cs
@@ -70,7 +70,7 @@ public sealed class Illidari : Faction
     StartingQuest = flameAndSorrow;
     AddQuest(flameAndSorrow);
 
-    var questBlackTemple = new QuestBlackTemple(flameAndSorrow, Regions.IllidanBlackTempleUnlock, AllLegends.Naga.Illidan);
+    var questBlackTemple = new QuestBlackTemple(flameAndSorrow);
     AddQuest(questBlackTemple);
 
     var questZangarmarsh = new QuestZangarmarsh(Regions.TelredorUnlock, AllLegends.Naga.Vashj);


### PR DESCRIPTION
Causes Illidan to abandon the Broken Isles completely when completing Return to Outland, refunding all buildings and teleporting all units to Outland. Actually affects all units on the map, just in case they make boats or something!

Closes #3597