### PR TITLE
Fix multiboard not registering events for non-player factions in singleplayer

### DIFF
--- a/src/MacroTools/UserInterface/FactionMultiboard.cs
+++ b/src/MacroTools/UserInterface/FactionMultiboard.cs
@@ -61,7 +61,7 @@ public sealed class FactionMultiboard
     FactionManager.AnyFactionNameChanged += OnFactionAnyFactionNameChanged;
     FactionManager.FactionRegistered += (_, faction) => { RegisterFaction(faction); };
 
-    foreach (var player in Util.EnumeratePlayers(playerslotstate.Playing, mapcontrol.User))
+    foreach (var player in Util.EnumeratePlayers())
     {
       var playerData = player.GetPlayerData();
       playerData.IncomeChanged += OnPlayerIncomeChanged;


### PR DESCRIPTION
In singleplayer, all factions are considered active, independently of whether or not there is any computer in their slot. So, we need to register events for all slots at all times, even if they may not be used.

Closes #3609 