### PR TITLE
fix: bump wcsharp to 3.3.8

### DIFF
--- a/src/MacroTools/MacroTools.csproj
+++ b/src/MacroTools/MacroTools.csproj
@@ -8,13 +8,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="WCSharp.Buffs" Version="3.3.4" />
-        <PackageReference Include="WCSharp.Effects" Version="3.3.4" />
-        <PackageReference Include="WCSharp.Events" Version="3.3.4" />
-        <PackageReference Include="WCSharp.Json" Version="3.3.4" />
-        <PackageReference Include="WCSharp.Lightnings" Version="3.3.4" />
-        <PackageReference Include="WCSharp.Missiles" Version="3.3.4" />
-        <PackageReference Include="WCSharp.SaveLoad" Version="3.3.4" />
+        <PackageReference Include="WCSharp.Buffs" Version="3.3.8" />
+        <PackageReference Include="WCSharp.Effects" Version="3.3.8" />
+        <PackageReference Include="WCSharp.Events" Version="3.3.8" />
+        <PackageReference Include="WCSharp.Json" Version="3.3.8" />
+        <PackageReference Include="WCSharp.Lightnings" Version="3.3.8" />
+        <PackageReference Include="WCSharp.Missiles" Version="3.3.8" />
+        <PackageReference Include="WCSharp.SaveLoad" Version="3.3.8" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Includes latest fixes to the event-, lightning-, and dummysystem

Closes #3706 