### PR TITLE
fix: don't show warning for completed objectives

### DIFF
--- a/src/WarcraftLegacies.Source/Objectives/TurnBased/ObjectiveExpire.cs
+++ b/src/WarcraftLegacies.Source/Objectives/TurnBased/ObjectiveExpire.cs
@@ -61,7 +61,7 @@ public sealed class ObjectiveExpire : Objective
 
   private void OnWarning()
   {
-    if (Progress != QuestProgress.Complete)
+    if (Progress == QuestProgress.Complete)
     {
       return;
     }


### PR DESCRIPTION
Fixes erroneous translation of the code https://github.com/AzerothWarsLR/WarcraftLegacies/blob/b2cb60344f351daa1950cadbf4816d295b3b0eee/src/WarcraftLegacies.Source/Objectives/TimeBased/ObjectiveExpire.cs#L49-L52