### PR TITLE
refactor: replace `EventHandler{<T>}` with `Action{<T>}`

### DIFF
--- a/src/MacroTools/Artifacts/Artifact.cs
+++ b/src/MacroTools/Artifacts/Artifact.cs
@@ -47,7 +47,7 @@ public sealed class Artifact
     private set
     {
       _locationType = value;
-      StatusChanged?.Invoke(this, this);
+      StatusChanged?.Invoke(this);
     }
     get => _locationType;
   }
@@ -78,32 +78,32 @@ public sealed class Artifact
   ///   Fired when the <see cref="player" /> owning the <see cref="unit" /> carrying the <see cref="Artifact" /> changes
   ///   <see cref="Faction" />.
   /// </summary>
-  public event EventHandler<Artifact>? FactionChanged;
+  public event Action<Artifact>? FactionChanged;
 
   /// <summary>
   ///   Fired when the <see cref="Artifact" /> is picked up by a unit.
   /// </summary>
-  public event EventHandler<Artifact>? PickedUp;
+  public event Action<Artifact>? PickedUp;
 
   /// <summary>
   ///   Fired when the <see cref="Artifact" /> is dropped.
   /// </summary>
-  public event EventHandler<Artifact>? Dropped;
+  public event Action<Artifact>? Dropped;
 
   /// <summary>
   ///   Fired when the <see cref="Artifact" /> is permanently destroyed.
   /// </summary>
-  public event EventHandler<Artifact>? Disposed;
+  public event Action<Artifact>? Disposed;
 
   /// <summary>
   ///   The owner of this <see cref="Artifact" /> changes.
   /// </summary>
-  public event EventHandler<Artifact>? OwnerChanged;
+  public event Action<Artifact>? OwnerChanged;
 
   /// <summary>
   ///   Any Artifact changes its <see cref="ArtifactLocationType" />.
   /// </summary>
-  public event EventHandler<Artifact>? StatusChanged;
+  public event Action<Artifact>? StatusChanged;
 
   /// <summary>
   ///   Pings the <see cref="Artifact" /> on the minimap for the given player.
@@ -123,7 +123,7 @@ public sealed class Artifact
   private void SetOwningPlayer(player? value)
   {
     OwningPlayer = value;
-    OwnerChanged?.Invoke(this, this);
+    OwnerChanged?.Invoke(this);
 
     LocationType = OwningPlayer != null ? ArtifactLocationType.Unit : ArtifactLocationType.Ground;
   }
@@ -131,7 +131,7 @@ public sealed class Artifact
   private void OnPickedUp()
   {
     OwningUnit = @event.Unit;
-    PickedUp?.Invoke(this, this);
+    PickedUp?.Invoke(this);
   }
 
   private void OnDropped()
@@ -144,10 +144,10 @@ public sealed class Artifact
 
     SetOwningPlayer(null);
     OwningUnit = null;
-    Dropped?.Invoke(this, this);
+    Dropped?.Invoke(this);
   }
 
-  private void OnPlayerFactionChange(object? sender, PlayerFactionChangeEventArgs e)
+  private void OnPlayerFactionChange(PlayerFactionChangeEventArgs e)
   {
     var owningFaction = OwningPlayer?.GetPlayerData().Faction;
     if (owningFaction == null)
@@ -157,7 +157,7 @@ public sealed class Artifact
 
     if (owningFaction == e.Player.GetPlayerData().Faction)
     {
-      FactionChanged?.Invoke(this, this);
+      FactionChanged?.Invoke(this);
     }
   }
 
@@ -174,7 +174,7 @@ public sealed class Artifact
   /// </summary>
   internal void Dispose()
   {
-    Disposed?.Invoke(this, this);
+    Disposed?.Invoke(this);
     Item.Dispose();
   }
 }

--- a/src/MacroTools/Artifacts/ArtifactManager.cs
+++ b/src/MacroTools/Artifacts/ArtifactManager.cs
@@ -23,7 +23,7 @@ public static class ArtifactManager
   /// <summary>
   /// Fired when an <see cref="Artifact"/> is newly registered to the system.
   /// </summary>
-  public static event EventHandler<Artifact>? ArtifactRegistered;
+  public static event Action<Artifact>? ArtifactRegistered;
 
   /// <summary>
   /// Returns the registered <see cref="Artifact"/> that represents the item with the provided item type ID.
@@ -55,7 +55,7 @@ public static class ArtifactManager
       artifact.Item.IsDroppedOnDeath = false;
       _artifactsByType[artifact.Item.TypeId] = artifact;
       _artifactsByName.Add(artifact.Item.Name.ToLower(), artifact);
-      ArtifactRegistered?.Invoke(artifact, artifact);
+      ArtifactRegistered?.Invoke(artifact);
       _allArtifacts.Add(artifact);
     }
     else

--- a/src/MacroTools/ControlPoints/ControlPoint.cs
+++ b/src/MacroTools/ControlPoints/ControlPoint.cs
@@ -15,13 +15,13 @@ public sealed class ControlPoint
   /// <summary>
   /// Fired when the <see cref="ControlLevel"/> of this <see cref="ControlPoint"/> changes.
   /// </summary>
-  public event EventHandler? ControlLevelChanged;
+  public event Action? ControlLevelChanged;
 
   /// <summary>
   /// The owner of this <see cref="ControlPoint"/> changed their alliances, or the <see cref="ControlPoint"/> itself
   /// changed ownership.
   /// </summary>
-  public event EventHandler<ControlPoint>? OwnerAllianceChanged;
+  public event Action<ControlPoint>? OwnerAllianceChanged;
 
   /// <summary>
   /// A tower that appears on the <see cref="ControlPoint"/> when its <see cref="ControlLevel"/> exceeds 0.
@@ -68,7 +68,7 @@ public sealed class ControlPoint
     set
     {
       _controlLevel = value;
-      ControlLevelChanged?.Invoke(this, EventArgs.Empty);
+      ControlLevelChanged?.Invoke();
     }
   }
 
@@ -99,5 +99,5 @@ public sealed class ControlPoint
   /// <summary>
   /// Signals that the <see cref="ControlPoint"/>'s <see cref="ControlPoint.Owner"/> has changed its alliances.
   /// </summary>
-  internal void SignalOwnerAllianceChange() => OwnerAllianceChanged?.Invoke(this, this);
+  internal void SignalOwnerAllianceChange() => OwnerAllianceChanged?.Invoke(this);
 }

--- a/src/MacroTools/ControlPoints/ControlPointManager.cs
+++ b/src/MacroTools/ControlPoints/ControlPointManager.cs
@@ -249,7 +249,7 @@ public sealed class ControlPointManager
 
   private void RegisterControlLevelChangeTrigger(ControlPoint controlPoint)
   {
-    controlPoint.ControlLevelChanged += (_, _) =>
+    controlPoint.ControlLevelChanged += () =>
     {
       if (controlPoint.ControlLevel > 0)
       {

--- a/src/MacroTools/Dialogues/TriggeredDialogue.cs
+++ b/src/MacroTools/Dialogues/TriggeredDialogue.cs
@@ -15,7 +15,7 @@ public sealed class TriggeredDialogue
   /// <summary>
   /// Fired when the <see cref="Dialogue"/> plays.
   /// </summary>
-  public event EventHandler<TriggeredDialogue>? Completed;
+  public event Action<TriggeredDialogue>? Completed;
 
   internal List<Objective> Objectives { get; }
 
@@ -54,13 +54,13 @@ public sealed class TriggeredDialogue
     }
 
     _inactive = true;
-    Completed?.Invoke(this, this);
+    Completed?.Invoke(this);
   }
 
   private void Fail()
   {
     _inactive = true;
-    Completed?.Invoke(this, this);
+    Completed?.Invoke(this);
   }
 
   /// <summary>
@@ -77,7 +77,7 @@ public sealed class TriggeredDialogue
     Objectives = objectives.ToList();
   }
 
-  internal void OnObjectiveCompleted(object? sender, Objective completedObjective)
+  internal void OnObjectiveCompleted(Objective _)
   {
     if (_inactive)
     {

--- a/src/MacroTools/Dialogues/TriggeredDialogueManager.cs
+++ b/src/MacroTools/Dialogues/TriggeredDialogueManager.cs
@@ -22,7 +22,7 @@ public static class TriggeredDialogueManager
     dialogue.Completed += DialogueFinished;
   }
 
-  private static void DialogueFinished(object? sender, TriggeredDialogue triggeredDialogue)
+  private static void DialogueFinished(TriggeredDialogue triggeredDialogue)
   {
     foreach (var objective in triggeredDialogue.Objectives)
     {

--- a/src/MacroTools/Extensions/PlayerData.cs
+++ b/src/MacroTools/Extensions/PlayerData.cs
@@ -80,33 +80,33 @@ public sealed class PlayerData
   /// <summary>
   /// Fired when the player leaves a team.
   /// </summary>
-  public event EventHandler<PlayerChangeTeamEventArgs>? PlayerLeftTeam;
+  public event Action<PlayerChangeTeamEventArgs>? PlayerLeftTeam;
 
   /// <summary>
   /// Fired when the player joins a team.
   /// </summary>
-  public event EventHandler<PlayerChangeTeamEventArgs>? PlayerJoinedTeam;
+  public event Action<PlayerChangeTeamEventArgs>? PlayerJoinedTeam;
 
   /// <summary>
   /// Fired when the player changes their <see cref="Faction"/>.
   /// </summary>
-  public event EventHandler<PlayerFactionChangeEventArgs>? ChangedFaction;
+  public event Action<PlayerFactionChangeEventArgs>? ChangedFaction;
 
   /// <summary>
   /// Fired when the player's income changes.
   /// </summary>
-  public event EventHandler<PlayerData>? IncomeChanged;
+  public event Action<PlayerData>? IncomeChanged;
 
   /// <summary>
   /// Fired when the <see cref="player" />'s <see cref="ControlPoint" />s change
   /// </summary>
-  public event EventHandler<PlayerData>? ControlPointsChanged;
+  public event Action<PlayerData>? ControlPointsChanged;
 
   /// <summary>
   /// Fired when any player changes <see cref="Faction"/>.
   /// Todo: remove this and use the instance version instead.
   /// </summary>
-  public static event EventHandler<PlayerFactionChangeEventArgs>? FactionChange;
+  public static event Action<PlayerFactionChangeEventArgs>? FactionChange;
 
   /// <summary>
   /// Controls who the player is allied to.
@@ -129,7 +129,7 @@ public sealed class PlayerData
     set
     {
       _bonusGoldPerMinute = value;
-      IncomeChanged?.Invoke(this, this);
+      IncomeChanged?.Invoke(this);
     }
   }
 
@@ -148,7 +148,7 @@ public sealed class PlayerData
       }
 
       _goldPerMinute = value;
-      IncomeChanged?.Invoke(this, this);
+      IncomeChanged?.Invoke(this);
     }
   }
 
@@ -196,8 +196,9 @@ public sealed class PlayerData
         }
       }
 
-      FactionChange?.Invoke(this, new PlayerFactionChangeEventArgs(_player, prevFaction));
-      ChangedFaction?.Invoke(this, new PlayerFactionChangeEventArgs(_player, prevFaction));
+      var eventArgs = new PlayerFactionChangeEventArgs(_player, prevFaction);
+      FactionChange?.Invoke(eventArgs);
+      ChangedFaction?.Invoke(eventArgs);
     }
   }
 
@@ -244,7 +245,7 @@ public sealed class PlayerData
     if (Team != null)
     {
       Team?.RemovePlayer(_player);
-      PlayerLeftTeam?.Invoke(this, new PlayerChangeTeamEventArgs(_player, Team));
+      PlayerLeftTeam?.Invoke(new PlayerChangeTeamEventArgs(_player, Team));
     }
 
     if (newTeam == null)
@@ -255,7 +256,7 @@ public sealed class PlayerData
     var prevTeam = Team;
     Team = newTeam;
     newTeam.AddPlayer(_player);
-    PlayerJoinedTeam?.Invoke(this, new PlayerChangeTeamEventArgs(_player, prevTeam));
+    PlayerJoinedTeam?.Invoke(new PlayerChangeTeamEventArgs(_player, prevTeam));
   }
 
   /// <summary>
@@ -264,7 +265,7 @@ public sealed class PlayerData
   public void AddControlPoint(ControlPoint controlPoint)
   {
     ControlPoints.Add(controlPoint);
-    ControlPointsChanged?.Invoke(this, this);
+    ControlPointsChanged?.Invoke(this);
   }
 
   /// <summary>
@@ -273,7 +274,7 @@ public sealed class PlayerData
   public void RemoveControlPoint(ControlPoint controlPoint)
   {
     ControlPoints.Remove(controlPoint);
-    ControlPointsChanged?.Invoke(this, this);
+    ControlPointsChanged?.Invoke(this);
   }
 
   public void SetObjectLevel(int obj, int level)

--- a/src/MacroTools/Factions/Faction.cs
+++ b/src/MacroTools/Factions/Faction.cs
@@ -128,7 +128,7 @@ public abstract class Faction
     {
       var formerName = _name;
       _name = value;
-      NameChanged?.Invoke(this, new FactionNameChangeEventArgs(this, formerName));
+      NameChanged?.Invoke(new FactionNameChangeEventArgs(this, formerName));
     }
   }
 
@@ -138,7 +138,7 @@ public abstract class Faction
     set
     {
       _icon = value;
-      IconChanged?.Invoke(this, this);
+      IconChanged?.Invoke(this);
     }
   }
 
@@ -195,25 +195,25 @@ public abstract class Faction
   }
 
   /// <summary>Fired when the <see cref="Faction" /> gains a <see cref="Power" />.</summary>
-  public event EventHandler<FactionPowerEventArgs>? PowerAdded;
+  public event Action<FactionPowerEventArgs>? PowerAdded;
 
   /// <summary>Fired when the <see cref="Faction" /> loses a <see cref="Power" />.</summary>
-  public event EventHandler<FactionPowerEventArgs>? PowerRemoved;
+  public event Action<FactionPowerEventArgs>? PowerRemoved;
 
   /// <summary>Invoked when <see cref="ScoreStatus"/> changes.</summary>
-  public event EventHandler<Faction>? ScoreStatusChanged;
+  public event Action<Faction>? ScoreStatusChanged;
 
   /// <summary>Invoked when one of the <see cref="Faction"/>'s <see cref="QuestData"/>s changes progress.</summary>
-  public event EventHandler<FactionQuestProgressChangedEventArgs>? QuestProgressChanged;
+  public event Action<FactionQuestProgressChangedEventArgs>? QuestProgressChanged;
 
   /// <summary>Fires when the <see cref="Faction" /> changes its name.</summary>
-  public event EventHandler<FactionNameChangeEventArgs>? NameChanged;
+  public event Action<FactionNameChangeEventArgs>? NameChanged;
 
   /// <summary>Fired when the <see cref="Faction"/>'s has changed.</summary>
-  public event EventHandler<Faction>? IconChanged;
+  public event Action<Faction>? IconChanged;
 
   /// <summary>Fired after the <see cref="Faction"/>'s status has changed.</summary>
-  public event EventHandler<Faction>? StatusChanged;
+  public event Action<Faction>? StatusChanged;
 
   /// <summary>
   /// Invoked after the <see cref="Faction"/> is registered to a <see cref="FactionManager"/>.
@@ -253,8 +253,8 @@ public abstract class Faction
 
     ScoreStatus = ScoreStatus.Defeated;
 
-    StatusChanged?.Invoke(this, this);
-    ScoreStatusChanged?.Invoke(this, this);
+    StatusChanged?.Invoke(this);
+    ScoreStatusChanged?.Invoke(this);
   }
 
 
@@ -288,7 +288,7 @@ public abstract class Faction
       power.OnAdd(Player);
     }
 
-    PowerAdded?.Invoke(this, new FactionPowerEventArgs(this, power));
+    PowerAdded?.Invoke(new FactionPowerEventArgs(this, power));
   }
 
   /// <summary>Removes a <see cref="Power" /> from this <see cref="Faction" />.</summary>
@@ -301,7 +301,7 @@ public abstract class Faction
       power.OnRemove(Player);
     }
 
-    PowerRemoved?.Invoke(this, new FactionPowerEventArgs(this, power));
+    PowerRemoved?.Invoke(new FactionPowerEventArgs(this, power));
   }
 
   /// <summary>
@@ -805,12 +805,12 @@ public abstract class Faction
     }
   }
 
-  private void OnQuestProgressChanged(object? sender, QuestProgressChangedEventArgs args)
+  private void OnQuestProgressChanged(QuestProgressChangedEventArgs args)
   {
     try
     {
       args.Quest.ApplyFactionProgress(this, args.Quest.Progress, args.FormerProgress);
-      QuestProgressChanged?.Invoke(this, new FactionQuestProgressChangedEventArgs(this, args.Quest, args.FormerProgress));
+      QuestProgressChanged?.Invoke(new FactionQuestProgressChangedEventArgs(this, args.Quest, args.FormerProgress));
     }
     catch (Exception ex)
     {

--- a/src/MacroTools/Factions/FactionManager.cs
+++ b/src/MacroTools/Factions/FactionManager.cs
@@ -24,12 +24,12 @@ public static class FactionManager
   /// <summary>
   ///   Fired when a <see cref="Faction" /> is registered to the <see cref="FactionManager" />.
   /// </summary>
-  public static event EventHandler<Faction>? FactionRegistered;
+  public static event Action<Faction>? FactionRegistered;
 
   /// <summary>
   /// Fired when any <see cref="Faction"/> changes its name.
   /// </summary>
-  public static event EventHandler<Faction>? AnyFactionNameChanged; //todo: remove this; shouldn't need static events of this nature
+  public static event Action<Faction>? AnyFactionNameChanged; //todo: remove this; shouldn't need static events of this nature
 
   /// <summary>
   /// How shared vision in <see cref="Team"/>s should behave.
@@ -94,13 +94,13 @@ public static class FactionManager
     });
   }
 
-  private static void OnFactionNameChange(object? sender, FactionNameChangeEventArgs args)
+  private static void OnFactionNameChange(FactionNameChangeEventArgs args)
   {
     try
     {
       _factionsByName.Remove(args.PreviousName);
       _factionsByName.Add(args.Faction.Name, args.Faction);
-      AnyFactionNameChanged?.Invoke(args.Faction, args.Faction);
+      AnyFactionNameChanged?.Invoke(args.Faction);
     }
     catch (Exception ex)
     {
@@ -166,7 +166,7 @@ public static class FactionManager
     }
 
     _allFactions.Add(faction);
-    FactionRegistered?.Invoke(faction, faction);
+    FactionRegistered?.Invoke(faction);
     faction.OnRegistered();
     faction.NameChanged += OnFactionNameChange;
 

--- a/src/MacroTools/Factions/FactionNameChangeEventArgs.cs
+++ b/src/MacroTools/Factions/FactionNameChangeEventArgs.cs
@@ -1,8 +1,6 @@
-﻿using System;
+﻿namespace MacroTools.Factions;
 
-namespace MacroTools.Factions;
-
-public sealed class FactionNameChangeEventArgs : EventArgs
+public sealed class FactionNameChangeEventArgs
 {
   public FactionNameChangeEventArgs(Faction faction, string previousName)
   {

--- a/src/MacroTools/Factions/FactionPowerEventArgs.cs
+++ b/src/MacroTools/Factions/FactionPowerEventArgs.cs
@@ -1,8 +1,6 @@
-﻿using System;
+﻿namespace MacroTools.Factions;
 
-namespace MacroTools.Factions;
-
-public sealed class FactionPowerEventArgs : EventArgs
+public sealed class FactionPowerEventArgs
 {
   public FactionPowerEventArgs(Faction faction, Power power)
   {

--- a/src/MacroTools/Factions/FactionQuestProgressChangedEventArgs.cs
+++ b/src/MacroTools/Factions/FactionQuestProgressChangedEventArgs.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using MacroTools.Quests;
+﻿using MacroTools.Quests;
 
 namespace MacroTools.Factions;
 
-public sealed class FactionQuestProgressChangedEventArgs : EventArgs
+public sealed class FactionQuestProgressChangedEventArgs
 {
   public Faction Faction { get; }
 

--- a/src/MacroTools/Factions/PlayerChangeTeamEventArgs.cs
+++ b/src/MacroTools/Factions/PlayerChangeTeamEventArgs.cs
@@ -1,8 +1,6 @@
-﻿using System;
+﻿namespace MacroTools.Factions;
 
-namespace MacroTools.Factions;
-
-public sealed class PlayerChangeTeamEventArgs : EventArgs
+public sealed class PlayerChangeTeamEventArgs
 {
   public player Player { get; }
   public Team? PreviousTeam { get; }

--- a/src/MacroTools/Factions/PlayerFactionChangeEventArgs.cs
+++ b/src/MacroTools/Factions/PlayerFactionChangeEventArgs.cs
@@ -1,8 +1,6 @@
-﻿using System;
+﻿namespace MacroTools.Factions;
 
-namespace MacroTools.Factions;
-
-public sealed class PlayerFactionChangeEventArgs : EventArgs
+public sealed class PlayerFactionChangeEventArgs
 {
   public player Player { get; }
   public Faction? PreviousFaction { get; }

--- a/src/MacroTools/Factions/Power.cs
+++ b/src/MacroTools/Factions/Power.cs
@@ -21,7 +21,7 @@ public abstract class Power
     protected set
     {
       _description = value;
-      DescriptionChanged?.Invoke(this, this);
+      DescriptionChanged?.Invoke(this);
     }
   }
 
@@ -29,7 +29,7 @@ public abstract class Power
 
   public bool OnCooldown { get; set; }
 
-  public event EventHandler<Power>? DescriptionChanged;
+  public event Action<Power>? DescriptionChanged;
 
   /// <summary>
   ///   Fired when the <see cref="Power" /> is added to a <see cref="player" />.

--- a/src/MacroTools/Legends/Capital.cs
+++ b/src/MacroTools/Legends/Capital.cs
@@ -30,7 +30,7 @@ public sealed class Capital : Legend
   private trigger? _deathTrig;
   private trigger? _ownerTrig;
 
-  private void OnProtectorDeath(object? sender, Protector protector)
+  private void OnProtectorDeath(Protector protector)
   {
     try
     {

--- a/src/MacroTools/Legends/CapitalManager.cs
+++ b/src/MacroTools/Legends/CapitalManager.cs
@@ -20,7 +20,7 @@ public static class CapitalManager
   /// <summary>
   /// Invoked when any <see cref="Capital"/> is destroyed.
   /// </summary>
-  public static event EventHandler<Capital>? CapitalDestroyed;
+  public static event Action<Capital>? CapitalDestroyed;
 
   /// <summary>
   /// Registers a <see cref="Capital"/> to the <see cref="CapitalManager"/>.
@@ -39,7 +39,7 @@ public static class CapitalManager
 
     _byUnit.Add(capital.Unit, capital);
     _allCapitals.Add(capital);
-    PlayerUnitEvents.Register(UnitEvent.Dies, () => { CapitalDestroyed?.Invoke(capital, capital); }, capital.Unit);
+    PlayerUnitEvents.Register(UnitEvent.Dies, () => CapitalDestroyed?.Invoke(capital), capital.Unit);
     TurnBasedHitpointsManager.Register(capital.Unit, HitPointPercentagePerTurn);
   }
 

--- a/src/MacroTools/Legends/Legend.cs
+++ b/src/MacroTools/Legends/Legend.cs
@@ -46,7 +46,7 @@ public abstract class Legend
 
       _unitType = _unit.UnitType;
       OnChangeUnit();
-      UnitChanged?.Invoke(this, new LegendChangeUnitEventArgs(this, previousUnit));
+      UnitChanged?.Invoke(new LegendChangeUnitEventArgs(this, previousUnit));
     }
   }
 
@@ -58,7 +58,7 @@ public abstract class Legend
   /// <summary>
   /// Invoked when the <see cref="Unit"/> value changes.
   /// </summary>
-  public event EventHandler<LegendChangeUnitEventArgs>? UnitChanged;
+  public event Action<LegendChangeUnitEventArgs>? UnitChanged;
 
   /// <summary>
   /// Initializes a new instance of the <see cref="Legend"/> class.
@@ -74,7 +74,7 @@ public abstract class Legend
       }
 
       Unit = trainedUnit;
-      ChangedOwner?.Invoke(this, new LegendChangeOwnerEventArgs(this));
+      ChangedOwner?.Invoke(new LegendChangeOwnerEventArgs(this));
     });
     Essential = false;
   }
@@ -120,13 +120,13 @@ public abstract class Legend
   /// <summary>
   ///   Fired when the <see cref="Legend" /> changes owner.
   /// </summary>
-  public event EventHandler<LegendChangeOwnerEventArgs>? ChangedOwner;
+  public event Action<LegendChangeOwnerEventArgs>? ChangedOwner;
 
   /// <summary>
   /// Invokes the <see cref="ChangedOwner"/> event.
   /// </summary>
   protected void OnChangeOwner(LegendChangeOwnerEventArgs args)
   {
-    ChangedOwner?.Invoke(this, args);
+    ChangedOwner?.Invoke(args);
   }
 }

--- a/src/MacroTools/Legends/LegendChangeOwnerEventArgs.cs
+++ b/src/MacroTools/Legends/LegendChangeOwnerEventArgs.cs
@@ -1,8 +1,6 @@
-﻿using System;
+﻿namespace MacroTools.Legends;
 
-namespace MacroTools.Legends;
-
-public sealed class LegendChangeOwnerEventArgs : EventArgs
+public sealed class LegendChangeOwnerEventArgs
 {
   public Legend Legend { get; }
   public player? PreviousOwner { get; }

--- a/src/MacroTools/Legends/LegendChangeUnitEventArgs.cs
+++ b/src/MacroTools/Legends/LegendChangeUnitEventArgs.cs
@@ -1,11 +1,9 @@
-﻿using System;
-
-namespace MacroTools.Legends;
+﻿namespace MacroTools.Legends;
 
 /// <summary>
 /// Event arguments for when a <see cref="Legend"/> changes unit.
 /// </summary>
-public sealed class LegendChangeUnitEventArgs : EventArgs
+public sealed class LegendChangeUnitEventArgs
 {
   /// <summary>
   /// The <see cref="Legend"/> triggering the event.

--- a/src/MacroTools/Legends/LegendDiedEventArgs.cs
+++ b/src/MacroTools/Legends/LegendDiedEventArgs.cs
@@ -1,11 +1,9 @@
-﻿using System;
-
-namespace MacroTools.Legends;
+﻿namespace MacroTools.Legends;
 
 /// <summary>
 /// Event arguments for when a <see cref="Legend"/> dies.
 /// </summary>
-public sealed class LegendDiedEventArgs : EventArgs
+public sealed class LegendDiedEventArgs
 {
   /// <summary>
   /// The <see cref="LegendaryHero"/> that died.

--- a/src/MacroTools/Legends/LegendaryHero.cs
+++ b/src/MacroTools/Legends/LegendaryHero.cs
@@ -32,12 +32,12 @@ public sealed class LegendaryHero : Legend
   /// <summary>
   ///   Fired when the <see cref="Legend" /> permanently dies.
   /// </summary>
-  public event EventHandler<LegendDiedEventArgs>? Died;
+  public event Action<LegendDiedEventArgs>? Died;
 
   /// <summary>
   /// Invoked when the <see cref="LegendaryHero"/> deals damage.
   /// </summary>
-  public event EventHandler? DealtDamage;
+  public event Action? DealtDamage;
 
   /// <summary>
   ///   If true, the Legend is permanently removed from the game upon death.
@@ -172,7 +172,7 @@ public sealed class LegendaryHero : Legend
   public void PermanentlyKill()
   {
     OnPermaDeath();
-    Died?.Invoke(this, new LegendDiedEventArgs
+    Died?.Invoke(new LegendDiedEventArgs
     {
       LegendaryHero = this,
       Permanent = true
@@ -189,7 +189,7 @@ public sealed class LegendaryHero : Legend
 
   private void OnDeath()
   {
-    Died?.Invoke(this, new LegendDiedEventArgs
+    Died?.Invoke(new LegendDiedEventArgs
     {
       LegendaryHero = this,
       Permanent = false
@@ -248,10 +248,7 @@ public sealed class LegendaryHero : Legend
     {
       OnChangeOwner(new LegendChangeOwnerEventArgs(this, @event.ChangingUnitPrevOwner));
     });
-    PlayerUnitEvents.Register(UnitEvent.Damaging, () =>
-    {
-      DealtDamage?.Invoke(this, EventArgs.Empty);
-    }, Unit);
+    PlayerUnitEvents.Register(UnitEvent.Damaging, () => DealtDamage?.Invoke(), Unit);
     Unit.SetColor(HasCustomColor ? _playerColor : Unit.Owner.Color);
     if (Unit.Experience < StartingXp)
     {

--- a/src/MacroTools/Legends/LegendaryHeroManager.cs
+++ b/src/MacroTools/Legends/LegendaryHeroManager.cs
@@ -46,7 +46,7 @@ public static class LegendaryHeroManager
   /// </summary>
   public static ReadOnlyCollection<LegendaryHero> GetAll() => _allLegendaryHeroes.AsReadOnly();
 
-  private static void OnLegendUnitChanged(object? sender, LegendChangeUnitEventArgs args)
+  private static void OnLegendUnitChanged(LegendChangeUnitEventArgs args)
   {
     if (args.PreviousUnit != null)
     {

--- a/src/MacroTools/Legends/Protector.cs
+++ b/src/MacroTools/Legends/Protector.cs
@@ -14,9 +14,9 @@ public sealed class Protector
     deathTrigger.RegisterUnitEvent(unit, unitevent.Death);
     deathTrigger.AddAction(() =>
     {
-      ProtectorDied?.Invoke(this, this);
+      ProtectorDied?.Invoke(this);
     });
   }
 
-  internal event EventHandler<Protector>? ProtectorDied;
+  internal event Action<Protector>? ProtectorDied;
 }

--- a/src/MacroTools/Quests/Objective.cs
+++ b/src/MacroTools/Quests/Objective.cs
@@ -66,7 +66,7 @@ public abstract class Objective
       _progress = value;
       UpdateDisplay();
 
-      ProgressChanged?.Invoke(this, this);
+      ProgressChanged?.Invoke(this);
     }
   }
 
@@ -119,7 +119,7 @@ public abstract class Objective
   }
 
   /// <summary>Fires after the <see cref="Progress"/> of this objective has changed.</summary>
-  public event EventHandler<Objective>? ProgressChanged;
+  public event Action<Objective>? ProgressChanged;
 
   /// <summary>
   /// Runs when this <see cref="Objective"/> is registered to a <see cref="QuestData"/>

--- a/src/MacroTools/Quests/QuestData.cs
+++ b/src/MacroTools/Quests/QuestData.cs
@@ -135,7 +135,7 @@ public abstract class QuestData
             throw new ArgumentOutOfRangeException(nameof(value));
         }
 
-        ProgressChanged?.Invoke(this, new QuestProgressChangedEventArgs(this, formerProgress));
+        ProgressChanged?.Invoke(new QuestProgressChangedEventArgs(this, formerProgress));
       }
       catch (Exception ex)
       {
@@ -273,7 +273,7 @@ public abstract class QuestData
   }
 
   /// <summary>Fired when the <see cref="QuestData" /> changes its progress.</summary>
-  internal event EventHandler<QuestProgressChangedEventArgs>? ProgressChanged;
+  internal event Action<QuestProgressChangedEventArgs>? ProgressChanged;
 
   /// <summary>Fired when the Quest is completed.</summary>
   protected virtual void OnComplete(Faction whichFaction)
@@ -333,7 +333,7 @@ public abstract class QuestData
     }
   }
 
-  private void OnQuestItemProgressChanged(object? sender, Objective changedObjective)
+  private void OnQuestItemProgressChanged(Objective _)
   {
     var allComplete = true;
     var anyFailed = false;

--- a/src/MacroTools/Quests/QuestProgressChangedEventArgs.cs
+++ b/src/MacroTools/Quests/QuestProgressChangedEventArgs.cs
@@ -1,8 +1,6 @@
-﻿using System;
+﻿namespace MacroTools.Quests;
 
-namespace MacroTools.Quests;
-
-public sealed class QuestProgressChangedEventArgs : EventArgs
+public sealed class QuestProgressChangedEventArgs
 {
   public QuestProgressChangedEventArgs(QuestData quest, QuestProgress formerProgress)
   {

--- a/src/MacroTools/UserInterface/Books/Artifacts/ArtifactBook.cs
+++ b/src/MacroTools/UserInterface/Books/Artifacts/ArtifactBook.cs
@@ -40,9 +40,9 @@ public sealed class ArtifactBook : Book<Artifact, ArtifactPage, ArtifactCard, Ar
     artifact.Disposed += OnArtifactDisposed;
   }
 
-  private void OnArtifactDisposed(object? sender, Artifact artifact) => ReRender();
+  private void OnArtifactDisposed(Artifact artifact) => ReRender();
 
-  private void ArtifactCreated(object? sender, Artifact artifact)
+  private void ArtifactCreated(Artifact artifact)
   {
     AddArtifact(artifact);
   }

--- a/src/MacroTools/UserInterface/Books/Artifacts/ArtifactCard.cs
+++ b/src/MacroTools/UserInterface/Books/Artifacts/ArtifactCard.cs
@@ -135,7 +135,7 @@ public sealed class ArtifactCard : Card<Artifact>
     }
   }
 
-  private void OnArtifactOwnerChanged(object? sender, Artifact artifact)
+  private void OnArtifactOwnerChanged(Artifact artifact)
   {
     try
     {
@@ -147,7 +147,7 @@ public sealed class ArtifactCard : Card<Artifact>
     }
   }
 
-  private void OnArtifactStatusChanged(object? sender, Artifact artifact)
+  private void OnArtifactStatusChanged(Artifact artifact)
   {
     try
     {
@@ -159,7 +159,7 @@ public sealed class ArtifactCard : Card<Artifact>
     }
   }
 
-  private void OnAnyFactionNameChanged(object? sender, Faction e)
+  private void OnAnyFactionNameChanged(Faction e)
   {
     try
     {

--- a/src/MacroTools/UserInterface/Books/Powers/PowerBook.cs
+++ b/src/MacroTools/UserInterface/Books/Powers/PowerBook.cs
@@ -66,17 +66,17 @@ public sealed class PowerBook : Book<Power, PowerPage, PowerCard, PowerPageFacto
     }
   }
 
-  private void OnFactionAddPower(object? sender, FactionPowerEventArgs factionPowerEventArgs)
+  private void OnFactionAddPower(FactionPowerEventArgs factionPowerEventArgs)
   {
     AddPower(factionPowerEventArgs.Power);
   }
 
-  private void OnPlayerChangedFaction(object? sender, PlayerFactionChangeEventArgs args)
+  private void OnPlayerChangedFaction(PlayerFactionChangeEventArgs args)
   {
     TrackedFaction = args.Player.GetPlayerData().Faction;
   }
 
-  private void OnFactionRemovePower(object? sender, FactionPowerEventArgs factionPowerEventArgs)
+  private void OnFactionRemovePower(FactionPowerEventArgs factionPowerEventArgs)
   {
     ReRender();
   }

--- a/src/MacroTools/UserInterface/Books/Powers/PowerCard.cs
+++ b/src/MacroTools/UserInterface/Books/Powers/PowerCard.cs
@@ -73,7 +73,7 @@ public sealed class PowerCard : Card<Power>
     AddFrame(_textFrame);
   }
 
-  private void OnPowerDescriptionChanged(object? sender, Power power)
+  private void OnPowerDescriptionChanged(Power power)
   {
     _textFrame.Text = power.Description;
   }

--- a/src/MacroTools/UserInterface/FactionMultiboard.cs
+++ b/src/MacroTools/UserInterface/FactionMultiboard.cs
@@ -61,16 +61,16 @@ public sealed class FactionMultiboard
       @event.ExpiredTimer.Dispose();
     });
 
-    PlayerData.FactionChange += (_, _) => { Instance?.Render(); };
+    PlayerData.FactionChange += _ => Instance?.Render();
     FactionManager.AnyFactionNameChanged += OnFactionAnyFactionNameChanged;
-    FactionManager.FactionRegistered += (_, faction) => { RegisterFaction(faction); };
+    FactionManager.FactionRegistered += RegisterFaction;
 
     foreach (var player in Util.EnumeratePlayers())
     {
       var playerData = player.GetPlayerData();
       playerData.IncomeChanged += OnPlayerIncomeChanged;
-      playerData.PlayerJoinedTeam += (_, _) => { Instance?.Render(); };
-      playerData.PlayerLeftTeam += (_, _) => { Instance?.Render(); };
+      playerData.PlayerJoinedTeam += _ => Instance?.Render();
+      playerData.PlayerLeftTeam += _ => Instance?.Render();
     }
 
     foreach (var faction in FactionManager.GetAllFactions())
@@ -188,16 +188,16 @@ public sealed class FactionMultiboard
 
   private static void RegisterFaction(Faction faction)
   {
-    faction.StatusChanged += (_, _) => { Instance?.Render(); };
+    faction.StatusChanged += _ => Instance?.Render();
     faction.IconChanged += OnFactionIconChanged;
   }
 
-  private static void OnFactionAnyFactionNameChanged(object? sender, Faction faction)
+  private static void OnFactionAnyFactionNameChanged(Faction faction)
   {
     Instance?.UpdateFactionRow(faction);
   }
 
-  private static void OnPlayerIncomeChanged(object? sender, PlayerData player)
+  private static void OnPlayerIncomeChanged(PlayerData player)
   {
     var faction = player.Faction;
     if (faction != null)
@@ -206,7 +206,7 @@ public sealed class FactionMultiboard
     }
   }
 
-  private static void OnFactionIconChanged(object? sender, Faction args)
+  private static void OnFactionIconChanged(Faction args)
   {
     Instance?.UpdateFactionRow(args);
   }

--- a/src/WarcraftLegacies.Source/FactionMechanics/Dalaran/Waygate.cs
+++ b/src/WarcraftLegacies.Source/FactionMechanics/Dalaran/Waygate.cs
@@ -22,13 +22,13 @@ public sealed class Waygate
   }
 
   public Waygate? Sister { get; set; }
-  public event EventHandler<Waygate>? Died;
+  public event Action<Waygate>? Died;
 
   private void OnDeath()
   {
     Disconnect();
     Sister?.Disconnect();
-    Died?.Invoke(this, this);
+    Died?.Invoke(this);
   }
 
   private void OnConstructed()

--- a/src/WarcraftLegacies.Source/FactionMechanics/Dalaran/WaygateManager.cs
+++ b/src/WarcraftLegacies.Source/FactionMechanics/Dalaran/WaygateManager.cs
@@ -12,7 +12,7 @@ public static class WaygateManager
   private static Waygate? WaygateA { get; set; }
   private static Waygate? WaygateB { get; set; }
 
-  private static void OnWaygateDied(object? sender, Waygate waygate)
+  private static void OnWaygateDied(Waygate waygate)
   {
     if (WaygateA == waygate)
     {

--- a/src/WarcraftLegacies.Source/FactionMechanics/Druids/CenariusGhost.cs
+++ b/src/WarcraftLegacies.Source/FactionMechanics/Druids/CenariusGhost.cs
@@ -26,7 +26,7 @@ public static class CenariusGhost
 
   public static void Setup(LegendaryHero cenarius, Faction druids)
   {
-    cenarius.Died += (sender, hero) => Dies(hero, druids);
+    cenarius.Died += hero => Dies(hero, druids);
     cenarius.DeathMessage =
       "Cenarius, Demigod of the Night Elves, has fallen. His spirit lives on, a mere echo of his former self.";
   }

--- a/src/WarcraftLegacies.Source/FactionMechanics/Scourge/TheFrozenThrone.cs
+++ b/src/WarcraftLegacies.Source/FactionMechanics/Scourge/TheFrozenThrone.cs
@@ -15,7 +15,7 @@ public static class TheFrozenThrone
   /// <summary>
   /// Invoked when the Frozen Throne's state has changed.
   /// </summary>
-  public static event EventHandler<FrozenThroneState>? FrozenThroneStateChanged;
+  public static event Action<FrozenThroneState>? FrozenThroneStateChanged;
 
   public static FrozenThroneState State
   {
@@ -23,7 +23,7 @@ public static class TheFrozenThrone
     private set
     {
       _state = value;
-      FrozenThroneStateChanged?.Invoke(null, value);
+      FrozenThroneStateChanged?.Invoke(value);
     }
   }
 
@@ -43,7 +43,7 @@ public static class TheFrozenThrone
   /// <summary>
   /// When the Scourge leaves, vacate Ner'zhul from the Throne.
   /// </summary>
-  private static void OnScourgeScoreStatusChanged(object? sender, Faction scourge)
+  private static void OnScourgeScoreStatusChanged(Faction scourge)
   {
     if (scourge.ScoreStatus != ScoreStatus.Defeated)
     {
@@ -157,7 +157,7 @@ public static class TheFrozenThrone
     Fracture();
   }
 
-  private static void OnLichKingDied(object? sender, LegendDiedEventArgs eventArgs)
+  private static void OnLichKingDied(LegendDiedEventArgs eventArgs)
   {
     if (eventArgs.Permanent && eventArgs.LegendaryHero.UnitType == UNIT_N023_LORD_OF_THE_SCOURGE_SCOURGE)
     {

--- a/src/WarcraftLegacies.Source/GameLogic/GameEnd/ControlPointVictory.cs
+++ b/src/WarcraftLegacies.Source/GameLogic/GameEnd/ControlPointVictory.cs
@@ -48,7 +48,7 @@ public static class ControlPointVictory
     }
   }
 
-  private static void ControlPointOwnerChanges(object? sender, ControlPoint controlPoint)
+  private static void ControlPointOwnerChanges(ControlPoint controlPoint)
   {
     if (_gameWon)
     {

--- a/src/WarcraftLegacies.Source/GameLogic/SharedQuestRepository.cs
+++ b/src/WarcraftLegacies.Source/GameLogic/SharedQuestRepository.cs
@@ -45,7 +45,7 @@ public static class SharedQuestRepository
     }
   }
 
-  private static void GiveFactionSharedQuests(object? sender, Faction faction)
+  private static void GiveFactionSharedQuests(Faction faction)
   {
     foreach (var quest in _sharedQuests)
     {

--- a/src/WarcraftLegacies.Source/Objectives/ArtifactBased/ObjectiveAcquireArtifact.cs
+++ b/src/WarcraftLegacies.Source/Objectives/ArtifactBased/ObjectiveAcquireArtifact.cs
@@ -19,10 +19,10 @@ public sealed class ObjectiveAcquireArtifact : Objective
   {
     Description = $"Acquire {target.Item.Name}";
     _target = target;
-    target.PickedUp += (_, _) =>
+    target.PickedUp += _ =>
       Progress = EligibleFactions.Contains(_target.OwningPlayer) ? QuestProgress.Complete : QuestProgress.Incomplete;
-    target.Dropped += (_, _) => Progress = QuestProgress.Incomplete;
-    target.Disposed += (_, _) => Progress = QuestProgress.Failed;
+    target.Dropped += _ => Progress = QuestProgress.Incomplete;
+    target.Disposed += _ => Progress = QuestProgress.Failed;
   }
 
   public override void OnAdd(Faction whichFaction)

--- a/src/WarcraftLegacies.Source/Objectives/ArtifactBased/ObjectiveNoOtherPlayerGetsArtifact.cs
+++ b/src/WarcraftLegacies.Source/Objectives/ArtifactBased/ObjectiveNoOtherPlayerGetsArtifact.cs
@@ -26,7 +26,7 @@ public sealed class ObjectiveNoOtherPlayerGetsArtifact : Objective
   public override void OnAdd(Faction faction)
   {
     Progress = QuestProgress.Complete;
-    _target.OwnerChanged += (_, _) =>
+    _target.OwnerChanged += _ =>
     {
       RefreshProgress(faction);
     };

--- a/src/WarcraftLegacies.Source/Objectives/Channel.cs
+++ b/src/WarcraftLegacies.Source/Objectives/Channel.cs
@@ -29,7 +29,7 @@ public sealed class Channel : IDisposable
   /// <summary>
   /// Fired when the <see cref="Channel"/> ends, successfully or otherwise.
   /// </summary>
-  public event EventHandler<Channel>? Finished;
+  public event Action<Channel>? Finished;
 
   /// <summary>
   /// If true, the caster finished the entire channel duration.
@@ -107,7 +107,7 @@ public sealed class Channel : IDisposable
     }
 
     FinishedWithoutInterruption = finishedWithoutInterruption;
-    Finished?.Invoke(this, this);
+    Finished?.Invoke(this);
   }
 
   private void Periodic()

--- a/src/WarcraftLegacies.Source/Objectives/ControlPointBased/ObjectiveControlLevel.cs
+++ b/src/WarcraftLegacies.Source/Objectives/ControlPointBased/ObjectiveControlLevel.cs
@@ -31,8 +31,8 @@ public sealed class ObjectiveControlLevel : Objective
     RefreshDescription();
     RefreshProgress();
 
-    _target.OwnerAllianceChanged += (_, _) => Refresh();
-    _target.ControlLevelChanged += (_, _) => Refresh();
+    _target.OwnerAllianceChanged += _ => Refresh();
+    _target.ControlLevelChanged += Refresh;
   }
 
   private void Refresh()

--- a/src/WarcraftLegacies.Source/Objectives/ControlPointBased/ObjectiveControlPoint.cs
+++ b/src/WarcraftLegacies.Source/Objectives/ControlPointBased/ObjectiveControlPoint.cs
@@ -53,7 +53,7 @@ public sealed class ObjectiveControlPoint : Objective
       ? QuestProgress.Complete
       : QuestProgress.Incomplete;
 
-    _target.OwnerAllianceChanged += (_, _) => RefreshProgress();
+    _target.OwnerAllianceChanged += _ => RefreshProgress();
   }
 
   private void RefreshProgress()

--- a/src/WarcraftLegacies.Source/Objectives/ControlPointBased/ObjectiveControlPoints.cs
+++ b/src/WarcraftLegacies.Source/Objectives/ControlPointBased/ObjectiveControlPoints.cs
@@ -48,7 +48,7 @@ public sealed class ObjectiveControlPoints : Objective
     }
   }
 
-  private void OnTargetOwnerAllianceChanged(object? sender, ControlPoint controlPoint)
+  private void OnTargetOwnerAllianceChanged(ControlPoint controlPoint)
   {
     SetControlPointProgress(controlPoint, IsPlayerOnSameTeamAsAnyEligibleFaction(controlPoint.Owner));
   }

--- a/src/WarcraftLegacies.Source/Objectives/FactionBased/ObjectiveSelfExists.cs
+++ b/src/WarcraftLegacies.Source/Objectives/FactionBased/ObjectiveSelfExists.cs
@@ -33,7 +33,7 @@ public sealed class ObjectiveSelfExists : Objective
     });
   }
 
-  private void OnAnyFactionScoreStatusChanged(object? sender, Faction faction)
+  private void OnAnyFactionScoreStatusChanged(Faction faction)
   {
     if (faction.ScoreStatus == ScoreStatus.Defeated)
     {

--- a/src/WarcraftLegacies.Source/Objectives/LegendBased/ObjectiveChannelRect.cs
+++ b/src/WarcraftLegacies.Source/Objectives/LegendBased/ObjectiveChannelRect.cs
@@ -65,7 +65,7 @@ public sealed class ObjectiveChannelRect : Objective
     _channel.Finished += OnChannelEnd;
   }
 
-  private void OnChannelEnd(object? sender, Channel channel)
+  private void OnChannelEnd(Channel channel)
   {
     if (channel.FinishedWithoutInterruption)
     {

--- a/src/WarcraftLegacies.Source/Objectives/LegendBased/ObjectiveControlCapital.cs
+++ b/src/WarcraftLegacies.Source/Objectives/LegendBased/ObjectiveControlCapital.cs
@@ -38,8 +38,8 @@ public sealed class ObjectiveControlCapital : Objective
     {
       Progress = QuestProgress.Complete;
     }
-    _target.ChangedOwner += (_, _) => { RecalculateProgress(); };
-    _target.UnitChanged += (_, _) => { RecalculateProgress(); };
+    _target.ChangedOwner += _ => RecalculateProgress();
+    _target.UnitChanged += _ => RecalculateProgress();
 
     var deathTrigger = trigger.Create();
     deathTrigger.RegisterUnitEvent(_target.Unit, unitevent.Death);

--- a/src/WarcraftLegacies.Source/Objectives/LegendBased/ObjectiveControlLegend.cs
+++ b/src/WarcraftLegacies.Source/Objectives/LegendBased/ObjectiveControlLegend.cs
@@ -39,7 +39,7 @@ public sealed class ObjectiveControlLegend : Objective
     }
   }
 
-  private void OnTargetChangeOwner(object? sender, LegendChangeOwnerEventArgs legendChangeOwnerEventArgs)
+  private void OnTargetChangeOwner(LegendChangeOwnerEventArgs legendChangeOwnerEventArgs)
   {
     if (_target.Unit != null && IsPlayerOnSameTeamAsAnyEligibleFaction(_target.Unit.Owner))
     {
@@ -51,7 +51,7 @@ public sealed class ObjectiveControlLegend : Objective
     }
   }
 
-  private void OnTargetPermaDeath(object? sender, LegendDiedEventArgs eventArgs)
+  private void OnTargetPermaDeath(LegendDiedEventArgs eventArgs)
   {
     if (_canFail && eventArgs.Permanent)
     {

--- a/src/WarcraftLegacies.Source/Objectives/LegendBased/ObjectiveDestroyAnyCapital.cs
+++ b/src/WarcraftLegacies.Source/Objectives/LegendBased/ObjectiveDestroyAnyCapital.cs
@@ -22,7 +22,7 @@ public sealed class ObjectiveDestroyAnyCapital : Objective
   /// <inheritdoc />
   public override void OnAdd(Faction faction)
   {
-    CapitalManager.CapitalDestroyed += (_, capital) =>
+    CapitalManager.CapitalDestroyed += capital =>
     {
       if (IsPlayerOnSameTeamAsAnyEligibleFaction(@event.KillingUnit.Owner))
       {

--- a/src/WarcraftLegacies.Source/Objectives/LegendBased/ObjectiveDontControlLegend.cs
+++ b/src/WarcraftLegacies.Source/Objectives/LegendBased/ObjectiveDontControlLegend.cs
@@ -40,7 +40,7 @@ public sealed class ObjectiveDontControlLegend : Objective
     }
   }
 
-  private void OnTargetChangeOwner(object? sender, LegendChangeOwnerEventArgs legendChangeOwnerEventArgs)
+  private void OnTargetChangeOwner(LegendChangeOwnerEventArgs legendChangeOwnerEventArgs)
   {
     if (_target.Unit != null && IsPlayerOnSameTeamAsAnyEligibleFaction(_target.Unit.Owner))
     {

--- a/src/WarcraftLegacies.Source/Objectives/LegendBased/ObjectiveLegendDead.cs
+++ b/src/WarcraftLegacies.Source/Objectives/LegendBased/ObjectiveLegendDead.cs
@@ -53,7 +53,7 @@ public sealed class ObjectiveLegendDead : Objective
     Description = CalculateDescription(_target);
   }
 
-  private void OnDeath(object? sender, LegendDiedEventArgs eventArgs)
+  private void OnDeath(LegendDiedEventArgs eventArgs)
   {
     if (PermanentOnly && !eventArgs.Permanent)
     {

--- a/src/WarcraftLegacies.Source/Objectives/LegendBased/ObjectiveLegendHasArtifact.cs
+++ b/src/WarcraftLegacies.Source/Objectives/LegendBased/ObjectiveLegendHasArtifact.cs
@@ -36,10 +36,10 @@ public sealed class ObjectiveLegendHasArtifact : Objective
     }
 
     _targetArtifact.OwnerChanged += OnArtifactOwnerChanged;
-    _targetArtifact.Disposed += (_, _) => Progress = QuestProgress.Failed;
+    _targetArtifact.Disposed += _ => Progress = QuestProgress.Failed;
   }
 
-  private void OnArtifactOwnerChanged(object? sender, Artifact artifact)
+  private void OnArtifactOwnerChanged(Artifact artifact)
   {
     Progress = _targetArtifact.OwningUnit != null && _targetArtifact.OwningUnit == _targetLegend.Unit
       ? QuestProgress.Complete

--- a/src/WarcraftLegacies.Source/Objectives/LegendBased/ObjectiveLegendMeetsLegend.cs
+++ b/src/WarcraftLegacies.Source/Objectives/LegendBased/ObjectiveLegendMeetsLegend.cs
@@ -16,7 +16,7 @@ public sealed class ObjectiveLegendMeetsLegend : Objective
   public ObjectiveLegendMeetsLegend(LegendaryHero damagingLegendaryHero, LegendaryHero legendaryHeroInRange)
   {
     Description = $"{damagingLegendaryHero.Name} has dealt damage within 500 units of {legendaryHeroInRange.Name}";
-    damagingLegendaryHero.DealtDamage += (_, _) =>
+    damagingLegendaryHero.DealtDamage += () =>
     {
       if (damagingLegendaryHero.Unit == null || legendaryHeroInRange.Unit == null)
       {

--- a/src/WarcraftLegacies.Source/Objectives/LegendBased/ObjectiveLegendNotPermanentlyDead.cs
+++ b/src/WarcraftLegacies.Source/Objectives/LegendBased/ObjectiveLegendNotPermanentlyDead.cs
@@ -27,7 +27,7 @@ public sealed class ObjectiveLegendNotPermanentlyDead : Objective
     PlayerUnitEvents.Register(UnitTypeEvent.FinishesTraining, OnAnyUnitTrain);
   }
 
-  private void OnTargetDied(object? sender, LegendDiedEventArgs eventArgs)
+  private void OnTargetDied(LegendDiedEventArgs eventArgs)
   {
     if (eventArgs.Permanent)
     {

--- a/src/WarcraftLegacies.Source/Objectives/LegendBased/ObjectiveLegendaryHeroTrained.cs
+++ b/src/WarcraftLegacies.Source/Objectives/LegendBased/ObjectiveLegendaryHeroTrained.cs
@@ -16,7 +16,7 @@ public sealed class ObjectiveLegendaryHeroTrained : Objective
     target.ChangedOwner += OnTargetChangeOwner;
   }
 
-  private void OnTargetChangeOwner(object? sender, LegendChangeOwnerEventArgs e)
+  private void OnTargetChangeOwner(LegendChangeOwnerEventArgs e)
   {
     Progress = QuestProgress.Complete;
   }

--- a/src/WarcraftLegacies.Source/Objectives/MetaBased/ObjectiveEitherOf.cs
+++ b/src/WarcraftLegacies.Source/Objectives/MetaBased/ObjectiveEitherOf.cs
@@ -48,7 +48,7 @@ public sealed class ObjectiveEitherOf : Objective
     Progress = QuestProgress.Incomplete;
   }
 
-  private void OnChildProgressChanged(object? sender, Objective objective)
+  private void OnChildProgressChanged(Objective _)
   {
     Update();
   }

--- a/src/WarcraftLegacies.Source/Objectives/ObjectiveFrozenThroneState.cs
+++ b/src/WarcraftLegacies.Source/Objectives/ObjectiveFrozenThroneState.cs
@@ -28,7 +28,7 @@ public sealed class ObjectiveFrozenThroneState : Objective
 
   public override void OnAdd(Faction whichFaction)
   {
-    TheFrozenThrone.FrozenThroneStateChanged += (_, state) =>
+    TheFrozenThrone.FrozenThroneStateChanged += state =>
     {
       Progress = state == _desiredState ? QuestProgress.Complete : QuestProgress.Failed;
       State = state;

--- a/src/WarcraftLegacies.Source/Objectives/QuestBased/ObjectiveFactionQuestComplete.cs
+++ b/src/WarcraftLegacies.Source/Objectives/QuestBased/ObjectiveFactionQuestComplete.cs
@@ -19,7 +19,7 @@ public sealed class ObjectiveFactionQuestComplete : Objective
     Progress = QuestProgress.Incomplete;
   }
 
-  private void OnQuestProgressChanged(object? sender, FactionQuestProgressChangedEventArgs args)
+  private void OnQuestProgressChanged(FactionQuestProgressChangedEventArgs args)
   {
     if (args.Quest == _target && args.Quest.Progress == QuestProgress.Complete)
     {

--- a/src/WarcraftLegacies.Source/Objectives/QuestBased/ObjectiveFactionQuestNotComplete.cs
+++ b/src/WarcraftLegacies.Source/Objectives/QuestBased/ObjectiveFactionQuestNotComplete.cs
@@ -19,7 +19,7 @@ public sealed class ObjectiveFactionQuestNotComplete : Objective
     Progress = QuestProgress.Complete;
   }
 
-  private void OnQuestProgressChanged(object? sender, FactionQuestProgressChangedEventArgs args)
+  private void OnQuestProgressChanged(FactionQuestProgressChangedEventArgs args)
   {
     if (args.Quest == _target && args.Quest.Progress == QuestProgress.Complete)
     {

--- a/src/WarcraftLegacies.Source/Objectives/QuestBased/ObjectiveQuestComplete.cs
+++ b/src/WarcraftLegacies.Source/Objectives/QuestBased/ObjectiveQuestComplete.cs
@@ -16,7 +16,7 @@ public sealed class ObjectiveQuestComplete : Objective
   /// <inheritdoc />
   public override void OnAdd(Faction faction) => faction.QuestProgressChanged += OnQuestProgressChanged;
 
-  private void OnQuestProgressChanged(object? sender, FactionQuestProgressChangedEventArgs args)
+  private void OnQuestProgressChanged(FactionQuestProgressChangedEventArgs args)
   {
     if (args.Quest != _target)
     {

--- a/src/WarcraftLegacies.Source/Objectives/QuestBased/ObjectiveQuestNotComplete.cs
+++ b/src/WarcraftLegacies.Source/Objectives/QuestBased/ObjectiveQuestNotComplete.cs
@@ -17,7 +17,7 @@ public sealed class ObjectiveQuestNotComplete : Objective
   /// <inheritdoc />
   public override void OnAdd(Faction faction) => faction.QuestProgressChanged += OnQuestProgressChanged;
 
-  private void OnQuestProgressChanged(object? sender, FactionQuestProgressChangedEventArgs args)
+  private void OnQuestProgressChanged(FactionQuestProgressChangedEventArgs args)
   {
     if (args.Quest != _target)
     {

--- a/src/WarcraftLegacies.Source/Objectives/UnitBased/ObjectiveSpendSkillPoints.cs
+++ b/src/WarcraftLegacies.Source/Objectives/UnitBased/ObjectiveSpendSkillPoints.cs
@@ -37,7 +37,7 @@ public sealed class ObjectiveSpendSkillPoints : Objective
     }
   }
 
-  private void OnHeroDied(object? sender, LegendDiedEventArgs eventArgs)
+  private void OnHeroDied(LegendDiedEventArgs eventArgs)
   {
     if (eventArgs.Permanent)
     {

--- a/src/WarcraftLegacies.Source/Powers/FontOfPower.cs
+++ b/src/WarcraftLegacies.Source/Powers/FontOfPower.cs
@@ -162,7 +162,7 @@ public sealed class FontOfPower : Power
     objective.ProgressChanged -= OnObjectiveProgressChanged;
   }
 
-  private void OnObjectiveProgressChanged(object? sender, Objective objective) => RefreshIsActive();
+  private void OnObjectiveProgressChanged(Objective _) => RefreshIsActive();
 
   private void RefreshIsActive() => IsActive = _objectives.Any(x => x.Progress == QuestProgress.Complete);
 }

--- a/src/WarcraftLegacies.Source/Powers/Immortality.cs
+++ b/src/WarcraftLegacies.Source/Powers/Immortality.cs
@@ -117,7 +117,7 @@ public sealed class Immortality : Power
     objective.ProgressChanged -= OnObjectiveProgressChanged;
   }
 
-  private void OnObjectiveProgressChanged(object? sender, Objective objective) => RefreshIsActive();
+  private void OnObjectiveProgressChanged(Objective _) => RefreshIsActive();
 
   private void RefreshIsActive() => IsActive = _objectives.Any(x => x.Progress == QuestProgress.Complete);
 }

--- a/test/WarcraftLegacies.Source.Tests/Objectives/TurnBased/ObjectiveExpireTests.cs
+++ b/test/WarcraftLegacies.Source.Tests/Objectives/TurnBased/ObjectiveExpireTests.cs
@@ -38,7 +38,7 @@ public sealed class ObjectiveExpireTests : GameTimeManagerTestsBase
     // Arrange
     var progressChangedCalls = 0;
     var objective = new ObjectiveExpire(1, "foo") { ShowsInQuestLog = false };
-    objective.ProgressChanged += (_, _) => progressChangedCalls++;
+    objective.ProgressChanged += _ => progressChangedCalls++;
 
     // Act
     GameTimeManager.SkipTurns(3);

--- a/test/WarcraftLegacies.Source.Tests/Objectives/TurnBased/ObjectiveTurnTests.cs
+++ b/test/WarcraftLegacies.Source.Tests/Objectives/TurnBased/ObjectiveTurnTests.cs
@@ -38,7 +38,7 @@ public sealed class ObjectiveTurnTests : GameTimeManagerTestsBase
     // Arrange
     var progressChangedCalls = 0;
     var objective = new ObjectiveTurn(1) { ShowsInQuestLog = false };
-    objective.ProgressChanged += (_, _) => progressChangedCalls++;
+    objective.ProgressChanged += _ => progressChangedCalls++;
 
     // Act
     GameTimeManager.SkipTurns(2);


### PR DESCRIPTION
I noticed that the event pattern in the solution never uses the `sender` object, so I propose replacing it with a simpler delegate that is not as verbose. This also fixes many places where it was implemented incorrectly and removes the `EventArgs` constraint to allow for more flexible events. Most objects just sent themselves as arguments