### PR TITLE
Offset Great War votes by -4

### DIFF
--- a/src/MacroTools/GameModes/GameModeManager.cs
+++ b/src/MacroTools/GameModes/GameModeManager.cs
@@ -92,6 +92,7 @@ public sealed class GameModeManager
     public GameModeVote(IGameMode gameMode)
     {
       GameMode = gameMode;
+      VoteCount = gameMode.VoteOffset;
     }
   }
 }

--- a/src/MacroTools/GameModes/IGameMode.cs
+++ b/src/MacroTools/GameModes/IGameMode.cs
@@ -3,9 +3,16 @@
 /// <summary>A game mode that players can vote on. Once one is chosen, it determines the game's basic settings.</summary>
 public interface IGameMode
 {
-  /// <summary>A user friendly name that players will see.</summary>
+  /// <summary>A user-friendly name that players will see.</summary>
   public string Name { get; }
 
   /// <summary>Fired when this <see cref="IGameMode"/> is successfully voted on.</summary>
   public void OnChoose();
+
+  /// <summary>
+  /// Total votes for this gamemode are offset by the specified amount.
+  /// <remarks>Set this to a negative value for gamemodes that should require a larger proportion of players to
+  /// vote for in order to pass.</remarks>
+  /// </summary>
+  public int VoteOffset { get; }
 }

--- a/src/WarcraftLegacies.Source/GameModes/ClosedAlliance.cs
+++ b/src/WarcraftLegacies.Source/GameModes/ClosedAlliance.cs
@@ -14,4 +14,7 @@ public sealed class ClosedAlliance : IGameMode
       .SetupControlPointVictory()
       .SetupUnallyCommand();
   }
+
+  /// <inheritdoc />
+  public int VoteOffset => 0;
 }

--- a/src/WarcraftLegacies.Source/GameModes/GreatWar.cs
+++ b/src/WarcraftLegacies.Source/GameModes/GreatWar.cs
@@ -16,4 +16,7 @@ public sealed class GreatWar : IGameMode
     this.SetupGreatWarTeams()
       .SetupAllianceCommands();
   }
+
+  /// <inheritdoc />
+  public int VoteOffset => -4;
 }

--- a/src/WarcraftLegacies.Source/GameModes/OpenAlliance.cs
+++ b/src/WarcraftLegacies.Source/GameModes/OpenAlliance.cs
@@ -14,4 +14,7 @@ public sealed class OpenAlliance : IGameMode
       .SetupAllianceCommands()
       .SetupControlPointVictory();
   }
+
+  /// <inheritdoc />
+  public int VoteOffset => 0;
 }


### PR DESCRIPTION
The "Great War" 8v8 gamemode is a non-standard, player-led gamemode organized through Discord. A few times lately, players have joined publicly hosted games and voted for 8v8, blindsiding casual players with an odd game mode - probably through force of habit. To mitigate this, I'm offsetting Great War votes by -4 to ensure at least 12 members out of a 16 person lobby have to vote for Great War for it to go through.

Closes #3823 