### PR TITLE
perf: share compilation across all test classes via collection fixture

### DIFF
--- a/test/WarcraftLegacies.Map.Tests/AbilityLevelSkipTests.cs
+++ b/test/WarcraftLegacies.Map.Tests/AbilityLevelSkipTests.cs
@@ -7,20 +7,14 @@ using Xunit.Sdk;
 
 namespace WarcraftLegacies.Map.Tests;
 
-public sealed class AbilityLevelSkipTests : IClassFixture<MapTestFixture>
+[Collection(nameof(MapTestCollection))]
+public sealed class AbilityLevelSkipTests(MapTestFixture fixture)
 {
-  private readonly MapTestFixture _mapTestFixture;
-
-  public AbilityLevelSkipTests(MapTestFixture mapTestFixture)
-  {
-    _mapTestFixture = mapTestFixture;
-  }
-
   [Fact]
   public void AllUnits_HaveValidFields()
   {
     var issues = new List<string>();
-    var objectDatabase = _mapTestFixture.ObjectDatabase;
+    var objectDatabase = fixture.ObjectDatabase;
 
     foreach (var unit in objectDatabase.GetAbilities())
     {

--- a/test/WarcraftLegacies.Map.Tests/ImportedModelTests.cs
+++ b/test/WarcraftLegacies.Map.Tests/ImportedModelTests.cs
@@ -5,7 +5,8 @@ using WarcraftLegacies.Map.Tests.TestSupport;
 
 namespace WarcraftLegacies.Map.Tests;
 
-public sealed class ImportedModelTests(MapTestFixture mapTestFixture) : IClassFixture<MapTestFixture>
+[Collection(nameof(MapTestCollection))]
+public sealed class ImportedModelTests(MapTestFixture fixture)
 {
   [Fact]
   public void AllModels_AreInActiveUse()
@@ -21,7 +22,7 @@ public sealed class ImportedModelTests(MapTestFixture mapTestFixture) : IClassFi
       .OrderBy(x => x)
       .ToList();
 
-    var activeModels = GetModelsUsedInMap(mapTestFixture.Map).OrderBy(x => x).ToHashSet();
+    var activeModels = GetModelsUsedInMap(fixture.Map).OrderBy(x => x).ToHashSet();
 
     var unusedModels = importedModels
       .Where(model => !activeModels.Contains(model))

--- a/test/WarcraftLegacies.Map.Tests/ObjectDataAccessibilityTests.cs
+++ b/test/WarcraftLegacies.Map.Tests/ObjectDataAccessibilityTests.cs
@@ -7,23 +7,24 @@ using Xunit.Sdk;
 
 namespace WarcraftLegacies.Map.Tests;
 
-public sealed class ObjectDataAccessibilityTests(MapTestFixture mapTestFixture) : IClassFixture<MapTestFixture>
+[Collection(nameof(MapTestCollection))]
+public sealed class ObjectDataAccessibilityTests(MapTestFixture fixture)
 {
   [Fact]
   public void UnreachableObjectCollection_HasNoExceptions()
   {
-    mapTestFixture.UnreachableObjects.Exceptions.Should().BeEmpty();
+    fixture.UnreachableObjects.Exceptions.Should().BeEmpty();
   }
 
   [Fact]
   public void AllResearches_CanBeAccessed()
   {
-    if (mapTestFixture.UnreachableObjects.Upgrades.Count <= 0)
+    if (fixture.UnreachableObjects.Upgrades.Count <= 0)
     {
       return;
     }
 
-    if (mapTestFixture.UnreachableObjects.Exceptions.Count != 0)
+    if (fixture.UnreachableObjects.Exceptions.Count != 0)
     {
       throw new XunitException("Test cannot start because there were issues building the UnreachableObjectCollection.");
     }
@@ -33,7 +34,7 @@ public sealed class ObjectDataAccessibilityTests(MapTestFixture mapTestFixture) 
       "Robk"
     };
 
-    var upgradesToCheck = mapTestFixture.UnreachableObjects.Upgrades
+    var upgradesToCheck = fixture.UnreachableObjects.Upgrades
       .Where(upgrade => !exceptions.Contains(GetReadableId(upgrade)))
       .ToList();
 
@@ -57,17 +58,17 @@ public sealed class ObjectDataAccessibilityTests(MapTestFixture mapTestFixture) 
   [Fact]
   public void AllUnits_CanBeTrained()
   {
-    if (mapTestFixture.UnreachableObjects.Units.Count <= 0)
+    if (fixture.UnreachableObjects.Units.Count <= 0)
     {
       return;
     }
 
-    if (mapTestFixture.UnreachableObjects.Exceptions.Count != 0)
+    if (fixture.UnreachableObjects.Exceptions.Count != 0)
     {
       throw new XunitException("Test cannot start because there were issues building the UnreachableObjectCollection.");
     }
 
-    var unitsToCheck = mapTestFixture.UnreachableObjects.Units.ToList();
+    var unitsToCheck = fixture.UnreachableObjects.Units.ToList();
 
     if (unitsToCheck.Count <= 0)
     {
@@ -89,17 +90,17 @@ public sealed class ObjectDataAccessibilityTests(MapTestFixture mapTestFixture) 
   [Fact]
   public void AllAbilities_CanBeCast()
   {
-    if (mapTestFixture.UnreachableObjects.Abilities.Count <= 0)
+    if (fixture.UnreachableObjects.Abilities.Count <= 0)
     {
       return;
     }
 
-    if (mapTestFixture.UnreachableObjects.Exceptions.Count != 0)
+    if (fixture.UnreachableObjects.Exceptions.Count != 0)
     {
       throw new XunitException("Test cannot start because there were issues building the UnreachableObjectCollection.");
     }
 
-    var abilitiesToCheck = mapTestFixture.UnreachableObjects.Abilities.ToList();
+    var abilitiesToCheck = fixture.UnreachableObjects.Abilities.ToList();
 
     if (abilitiesToCheck.Count <= 0)
     {
@@ -121,14 +122,14 @@ public sealed class ObjectDataAccessibilityTests(MapTestFixture mapTestFixture) 
   [Fact]
   public void AllDoodads_ArePlaced()
   {
-    var unplacedDoodads = mapTestFixture.UnreachableObjects.Doodads;
+    var unplacedDoodads = fixture.UnreachableObjects.Doodads;
 
     if (unplacedDoodads.Count <= 0)
     {
       return;
     }
 
-    if (mapTestFixture.UnreachableObjects.Exceptions.Count != 0)
+    if (fixture.UnreachableObjects.Exceptions.Count != 0)
     {
       throw new XunitException("Test cannot start because there were issues building the UnreachableObjectCollection.");
     }

--- a/test/WarcraftLegacies.Map.Tests/RulesTests/UnitEditorSuffixTests.cs
+++ b/test/WarcraftLegacies.Map.Tests/RulesTests/UnitEditorSuffixTests.cs
@@ -5,7 +5,8 @@ using Xunit.Sdk;
 
 namespace WarcraftLegacies.Map.Tests.RulesTests;
 
-public sealed class UnitEditorSuffixTests(MapTestFixture mapTestFixture) : IClassFixture<MapTestFixture>
+[Collection(nameof(MapTestCollection))]
+public sealed class UnitEditorSuffixTests(MapTestFixture fixture)
 {
   private static readonly List<string> _approvedEditorSuffixes =
   [
@@ -47,7 +48,7 @@ public sealed class UnitEditorSuffixTests(MapTestFixture mapTestFixture) : IClas
   public void AllUnits_FirstWordOfEditorSuffix_MatchesApprovedList()
   {
     var issues = new List<string>();
-    var objectDatabase = mapTestFixture.ObjectDatabase;
+    var objectDatabase = fixture.ObjectDatabase;
 
     foreach (var unit in objectDatabase.GetUnits().ToArray())
     {

--- a/test/WarcraftLegacies.Map.Tests/TestSupport/MapTestCollection.cs
+++ b/test/WarcraftLegacies.Map.Tests/TestSupport/MapTestCollection.cs
@@ -1,0 +1,6 @@
+﻿namespace WarcraftLegacies.Map.Tests.TestSupport;
+
+[CollectionDefinition(nameof(MapTestCollection))]
+public sealed class MapTestCollection : ICollectionFixture<MapTestFixture>
+{
+}

--- a/test/WarcraftLegacies.Map.Tests/ValidityTests/AbilityValidityTests.cs
+++ b/test/WarcraftLegacies.Map.Tests/ValidityTests/AbilityValidityTests.cs
@@ -9,12 +9,13 @@ using Xunit.Sdk;
 
 namespace WarcraftLegacies.Map.Tests.ValidityTests;
 
-public sealed class AbilityValidityTests(MapTestFixture mapTestFixture) : IClassFixture<MapTestFixture>
+[Collection(nameof(MapTestCollection))]
+public sealed class AbilityValidityTests(MapTestFixture fixture)
 {
   [Fact]
   public void AllAbilities_HaveValidFields()
   {
-    var objectDatabase = mapTestFixture.ObjectDatabase;
+    var objectDatabase = fixture.ObjectDatabase;
 
     var exceptionMessageBuilder = new StringBuilder();
     foreach (var ability in objectDatabase.GetAbilities())
@@ -36,7 +37,7 @@ public sealed class AbilityValidityTests(MapTestFixture mapTestFixture) : IClass
   [Fact]
   public void AllAbilities_CanBeHandledByWar3Net()
   {
-    var objectDatabase = mapTestFixture.ObjectDatabase;
+    var objectDatabase = fixture.ObjectDatabase;
 
     var exceptionMessageBuilder = new StringBuilder();
     foreach (var ability in objectDatabase.GetAbilities())

--- a/test/WarcraftLegacies.Map.Tests/ValidityTests/UnitValidityTests.cs
+++ b/test/WarcraftLegacies.Map.Tests/ValidityTests/UnitValidityTests.cs
@@ -7,13 +7,14 @@ using Xunit.Sdk;
 
 namespace WarcraftLegacies.Map.Tests.ValidityTests;
 
-public sealed class UnitValidityTests(MapTestFixture mapTestFixture) : IClassFixture<MapTestFixture>
+[Collection(nameof(MapTestCollection))]
+public sealed class UnitValidityTests(MapTestFixture fixture)
 {
   [Fact]
   public void AllUnits_HaveValidFields()
   {
     var issues = new List<string>();
-    var objectDatabase = mapTestFixture.ObjectDatabase;
+    var objectDatabase = fixture.ObjectDatabase;
 
     foreach (var unit in objectDatabase.GetUnits().ToArray())
     {


### PR DESCRIPTION
* Tests now run 4x faster (on my machine) by reusing the same compilation