### PR TITLE
fix: doomhammer tooltip references `YBRR` instead of `YBRO`

### DIFF
--- a/mapdata/WarcraftLegacies/ItemData/I004.json
+++ b/mapdata/WarcraftLegacies/ItemData/I004.json
@@ -50,7 +50,7 @@
     {
       "Id": "utub",
       "Type": 3,
-      "Value": "|cffff8c00Artifact|r|nIncreases Strength and Intelligence by 4. Can be used to cast Roar, increasing the attack damage of nearby friendly units by \u003CYBRR,DataA1,%\u003E% for \u003CYBRR,Dur1\u003E seconds.|n|cffffcc00Lore|r|n|cffffdeadForged in the magma pits of Draenor, this oak and granite hammer is the prophesized weapon of the Doomhammer Lineage. Passed down to Thrall in Orgrim\u0027s dying breath, it is a symbol of the resurrection of the Horde.\r\n"
+      "Value": "|cffff8c00Artifact|r|nIncreases Strength and Intelligence by 4. Can be used to cast Roar, increasing the attack damage of nearby friendly units by \u003CYBRO,DataA1,%\u003E% for \u003CYBRO,Dur1\u003E seconds.|n|cffffcc00Lore|r|n|cffffdeadForged in the magma pits of Draenor, this oak and granite hammer is the prophesized weapon of the Doomhammer Lineage. Passed down to Thrall in Orgrim\u0027s dying breath, it is a symbol of the resurrection of the Horde.\r\n"
     }
   ]
 }


### PR DESCRIPTION
Split from #3928 