### PR TITLE
chore: remove extraneous ability modifications

### DIFF
--- a/mapdata/WarcraftLegacies/AbilityData/A000.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A000.json
@@ -22,11 +22,6 @@
       "Value": 250
     },
     {
-      "Level": 4,
-      "Id": "amcs",
-      "Value": 400
-    },
-    {
       "Level": 2,
       "Pointer": 1,
       "Id": "Hmt1",
@@ -37,12 +32,6 @@
       "Pointer": 1,
       "Id": "Hmt1",
       "Value": 84
-    },
-    {
-      "Level": 4,
-      "Pointer": 1,
-      "Id": "Hmt1",
-      "Value": 96
     },
     {
       "Level": 1,
@@ -78,12 +67,6 @@
       "Value": "allies,enemies,friend,ground,invulnerable,mechanical,neutral,notself,organic,player,structure,vulnerable"
     },
     {
-      "Level": 4,
-      "Id": "atar",
-      "Type": 3,
-      "Value": "allies,ground,invulnerable,neutral,nonsapper,player,structure,vulnerable"
-    },
-    {
       "Level": 2,
       "Pointer": 2,
       "Id": "Hmt2",
@@ -96,13 +79,6 @@
       "Id": "Hmt2",
       "Type": 2,
       "Value": 1
-    },
-    {
-      "Level": 4,
-      "Pointer": 2,
-      "Id": "Hmt2",
-      "Type": 2,
-      "Value": 0
     },
     {
       "Id": "alsk",
@@ -194,12 +170,6 @@
       "Value": "Shifting Sands - [|cffffcc00Level 3|r]"
     },
     {
-      "Level": 4,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Mass Teleport- [|cffffcc00Level 4|r]"
-    },
-    {
       "Level": 2,
       "Id": "aub1",
       "Type": 3,
@@ -210,12 +180,6 @@
       "Id": "aub1",
       "Type": 3,
       "Value": "After 1 seconds, teleports \u003CA000,DataA3\u003E of the player\u0027s nearby units, including the caster, to a friendly ground unit or structure in \u003CA000,Rng3\u003E range."
-    },
-    {
-      "Level": 4,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Teleports 96 of the player\u0027s nearby units, including Jaina, to a friendly ground unit or structure."
     },
     {
       "Id": "aart",

--- a/mapdata/WarcraftLegacies/AbilityData/A00D.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A00D.json
@@ -98,11 +98,6 @@
       "Value": "Destroy the Corrupted Sunwell"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTNMind Crush.blp"
-    },
-    {
       "Id": "arpx",
       "Value": 3
     },
@@ -110,16 +105,6 @@
       "Id": "arhk",
       "Type": 3,
       "Value": "Z"
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Inspire Madness - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Takes control of several random enemy units in the target area. After 30 seconds, each unit controlled this way dies of madness.|n|n|cffffcc00Level 1|r - Controls 6 units. |n|cffffcc00Level 2|r - Controls 10 units. |n|cffffcc00Level 3|r - Controls 14 units."
     },
     {
       "Id": "atat",

--- a/mapdata/WarcraftLegacies/AbilityData/A00F.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A00F.json
@@ -12,61 +12,12 @@
       "Value": 20
     },
     {
-      "Level": 2,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 60
-    },
-    {
-      "Level": 3,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 60
-    },
-    {
-      "Level": 4,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 60
-    },
-    {
       "Level": 1,
       "Id": "amcs",
       "Value": 25
     },
     {
-      "Level": 2,
-      "Id": "amcs",
-      "Value": 135
-    },
-    {
-      "Level": 4,
-      "Id": "amcs",
-      "Value": 155
-    },
-    {
       "Level": 1,
-      "Pointer": 1,
-      "Id": "Ncl1",
-      "Type": 2,
-      "Value": 0.5
-    },
-    {
-      "Level": 2,
-      "Pointer": 1,
-      "Id": "Ncl1",
-      "Type": 2,
-      "Value": 0.5
-    },
-    {
-      "Level": 3,
-      "Pointer": 1,
-      "Id": "Ncl1",
-      "Type": 2,
-      "Value": 0.5
-    },
-    {
-      "Level": 4,
       "Pointer": 1,
       "Id": "Ncl1",
       "Type": 2,
@@ -79,64 +30,13 @@
       "Value": 17
     },
     {
-      "Level": 3,
-      "Pointer": 3,
-      "Id": "Ncl3",
-      "Value": 17
-    },
-    {
-      "Level": 4,
-      "Pointer": 3,
-      "Id": "Ncl3",
-      "Value": 17
-    },
-    {
       "Level": 1,
       "Pointer": 5,
       "Id": "Ncl5",
       "Value": 0
     },
     {
-      "Level": 2,
-      "Pointer": 5,
-      "Id": "Ncl5",
-      "Value": 0
-    },
-    {
-      "Level": 3,
-      "Pointer": 5,
-      "Id": "Ncl5",
-      "Value": 0
-    },
-    {
-      "Level": 4,
-      "Pointer": 5,
-      "Id": "Ncl5",
-      "Value": 0
-    },
-    {
       "Level": 1,
-      "Pointer": 6,
-      "Id": "Ncl6",
-      "Type": 3,
-      "Value": "howlofterror"
-    },
-    {
-      "Level": 2,
-      "Pointer": 6,
-      "Id": "Ncl6",
-      "Type": 3,
-      "Value": "howlofterror"
-    },
-    {
-      "Level": 3,
-      "Pointer": 6,
-      "Id": "Ncl6",
-      "Type": 3,
-      "Value": "howlofterror"
-    },
-    {
-      "Level": 4,
       "Pointer": 6,
       "Id": "Ncl6",
       "Type": 3,
@@ -150,17 +50,6 @@
     {
       "Id": "alev",
       "Value": 1
-    },
-    {
-      "Level": 3,
-      "Id": "amcs",
-      "Value": 145
-    },
-    {
-      "Level": 2,
-      "Pointer": 3,
-      "Id": "Ncl3",
-      "Value": 17
     },
     {
       "Id": "aher",
@@ -247,46 +136,10 @@
       "Value": "Rend Soul"
     },
     {
-      "Level": 2,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Reap - [|cffffcc00Level 2|r]"
-    },
-    {
-      "Level": 3,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Reap - [|cffffcc00Level 3|r]"
-    },
-    {
-      "Level": 4,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Reap - [|cffffcc00Level 4|r]"
-    },
-    {
       "Level": 1,
       "Id": "aub1",
       "Type": 3,
       "Value": "Sacrifices a friendly unit to convert 35% of its hit points into mana, and 25% of its hit points into hit points, for Kel\u0027thuzad, then summons a Revenant lasting 45 seconds with the Persistent Soul ability at its corpse.|n|n|cfff5962dPersistent Soul:|R When this unit dies, it reanimates the highest level nearby corpse for 40 seconds."
-    },
-    {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Instantly kills the 5 lowest level non-Hero nearby enemy units, granting the caster 5 Strength for each unit slain for 30 seconds."
-    },
-    {
-      "Level": 3,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Instantly kills the 7 lowest level non-Hero nearby enemy units, granting the caster 5 Strength for each unit slain for 30 seconds."
-    },
-    {
-      "Level": 4,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Instantly kills the 9 lowest level non-Hero nearby enemy units, granting the caster 5 Strength for each unit slain for 30 seconds."
     },
     {
       "Id": "abpx",

--- a/mapdata/WarcraftLegacies/AbilityData/A00F.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A00F.json
@@ -101,11 +101,6 @@
       "Value": "Rend Soul"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTNCursedScythe.blp"
-    },
-    {
       "Id": "arpx",
       "Value": 1
     },
@@ -113,16 +108,6 @@
       "Id": "arhk",
       "Type": 3,
       "Value": "W"
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Reap - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Instantly kills the lowest level nearby non-Hero enemy units, granting the caster 5 Strength for each unit slain for 30 seconds. |n|n|cffffcc00Level 1|r - Kills 3 units.|n|cffffcc00Level 2|r - Kills 5 units.|n|cffffcc00Level 3|r - Kills 7 units.|n|cffffcc00Level 4|r - Kills 9 units."
     },
     {
       "Id": "atat",

--- a/mapdata/WarcraftLegacies/AbilityData/A00T.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A00T.json
@@ -61,11 +61,6 @@
       "Value": "Q"
     },
     {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "The Warden hurls a flurry of knives, damaging nearby enemies. |n|n|cffffcc00Level 1|r - \u003CAEfk,DataA1\u003E damage per target. |n|cffffcc00Level 2|r - \u003CAEfk,DataA2\u003E damage per target. |n|cffffcc00Level 3|r - \u003CAEfk,DataA3\u003E damage per target. |n|cffffcc00Level 4|r - \u003CAEfk,DataA4\u003E damage per target."
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A01I.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A01I.json
@@ -74,24 +74,9 @@
       "Value": "Crusade Aura"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTNDisenchant.blp"
-    },
-    {
       "Id": "arhk",
       "Type": 3,
       "Value": "E"
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Blazing Aura - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Undead and Demons are weakened in the face of the Light. Decreases hitpoint regeneration and movement speed of nearby enemy units. |n|n|cffffcc00Level 1|r - 50% degeneration, 3% movement speed reduction.|n|cffffcc00Level 2|r - 100% degeneration, 6% movement speed reduction.|n|cffffcc00Level 3|r - 200% degeneration, 9% movement speed reduction."
     },
     {
       "Id": "atat",

--- a/mapdata/WarcraftLegacies/AbilityData/A01N.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A01N.json
@@ -113,11 +113,6 @@
       "Value": "Q"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTNMassFrostArmor.blp"
-    },
-    {
       "Id": "arpx",
       "Value": 1
     },
@@ -125,16 +120,6 @@
       "Id": "arhk",
       "Type": 3,
       "Value": "W"
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Mass Frost Armor - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Grants Frost Armor to all friendly unit in a target area for \u003CA13S,DataA1\u003E seconds. |n|n|cffffcc00Level 1|r - Grants \u003CA13S,DataB1\u003E armor and has a \u003CA13R,Cool1\u003E second cooldown.|n|cffffcc00Level 2|r - Grants \u003CA13S,DataB2\u003E armor and has a \u003CA13R,Cool2\u003E second cooldown.|n|cffffcc00Level 3|r - Grants \u003CA13S,DataB3\u003E armor and has a \u003CA13R,Cool3\u003E second cooldown.|n|cffffcc00Level 4|r - Grants \u003CA13S,DataB4\u003E armor and has a \u003CA13R,Cool4\u003E second cooldown."
     },
     {
       "Id": "atat",

--- a/mapdata/WarcraftLegacies/AbilityData/A01N.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A01N.json
@@ -12,52 +12,6 @@
       "Value": 250
     },
     {
-      "Level": 2,
-      "Id": "aare",
-      "Type": 2,
-      "Value": 200
-    },
-    {
-      "Level": 3,
-      "Id": "aare",
-      "Type": 2,
-      "Value": 200
-    },
-    {
-      "Level": 4,
-      "Id": "aare",
-      "Type": 2,
-      "Value": 200
-    },
-    {
-      "Level": 2,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 25
-    },
-    {
-      "Level": 3,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 15
-    },
-    {
-      "Level": 4,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 5
-    },
-    {
-      "Level": 2,
-      "Id": "amcs",
-      "Value": 135
-    },
-    {
-      "Level": 4,
-      "Id": "amcs",
-      "Value": 155
-    },
-    {
       "Level": 1,
       "Pointer": 1,
       "Id": "Ncl1",
@@ -65,46 +19,7 @@
       "Value": 0.5
     },
     {
-      "Level": 2,
-      "Pointer": 1,
-      "Id": "Ncl1",
-      "Type": 2,
-      "Value": 0.5
-    },
-    {
-      "Level": 3,
-      "Pointer": 1,
-      "Id": "Ncl1",
-      "Type": 2,
-      "Value": 0.5
-    },
-    {
-      "Level": 4,
-      "Pointer": 1,
-      "Id": "Ncl1",
-      "Type": 2,
-      "Value": 0.5
-    },
-    {
       "Level": 1,
-      "Pointer": 2,
-      "Id": "Ncl2",
-      "Value": 2
-    },
-    {
-      "Level": 2,
-      "Pointer": 2,
-      "Id": "Ncl2",
-      "Value": 2
-    },
-    {
-      "Level": 3,
-      "Pointer": 2,
-      "Id": "Ncl2",
-      "Value": 2
-    },
-    {
-      "Level": 4,
       "Pointer": 2,
       "Id": "Ncl2",
       "Value": 2
@@ -116,64 +31,13 @@
       "Value": 19
     },
     {
-      "Level": 3,
-      "Pointer": 3,
-      "Id": "Ncl3",
-      "Value": 19
-    },
-    {
-      "Level": 4,
-      "Pointer": 3,
-      "Id": "Ncl3",
-      "Value": 19
-    },
-    {
       "Level": 1,
       "Pointer": 5,
       "Id": "Ncl5",
       "Value": 0
     },
     {
-      "Level": 2,
-      "Pointer": 5,
-      "Id": "Ncl5",
-      "Value": 0
-    },
-    {
-      "Level": 3,
-      "Pointer": 5,
-      "Id": "Ncl5",
-      "Value": 0
-    },
-    {
-      "Level": 4,
-      "Pointer": 5,
-      "Id": "Ncl5",
-      "Value": 0
-    },
-    {
       "Level": 1,
-      "Pointer": 6,
-      "Id": "Ncl6",
-      "Type": 3,
-      "Value": "flamestrike"
-    },
-    {
-      "Level": 2,
-      "Pointer": 6,
-      "Id": "Ncl6",
-      "Type": 3,
-      "Value": "flamestrike"
-    },
-    {
-      "Level": 3,
-      "Pointer": 6,
-      "Id": "Ncl6",
-      "Type": 3,
-      "Value": "flamestrike"
-    },
-    {
-      "Level": 4,
       "Pointer": 6,
       "Id": "Ncl6",
       "Type": 3,
@@ -185,37 +49,8 @@
       "Value": "other"
     },
     {
-      "Level": 2,
-      "Id": "aran",
-      "Type": 2,
-      "Value": 600
-    },
-    {
-      "Level": 3,
-      "Id": "aran",
-      "Type": 2,
-      "Value": 600
-    },
-    {
-      "Level": 4,
-      "Id": "aran",
-      "Type": 2,
-      "Value": 600
-    },
-    {
       "Id": "alev",
       "Value": 1
-    },
-    {
-      "Level": 3,
-      "Id": "amcs",
-      "Value": 145
-    },
-    {
-      "Level": 2,
-      "Pointer": 3,
-      "Id": "Ncl3",
-      "Value": 19
     },
     {
       "Id": "aher",
@@ -313,46 +148,10 @@
       "Value": "Mass Ensnare"
     },
     {
-      "Level": 2,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Mass Frost Armor - [|cffffcc00Level 2|r]"
-    },
-    {
-      "Level": 3,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Mass Frost Armor - [|cffffcc00Level 3|r]"
-    },
-    {
-      "Level": 4,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Mass Frost Armor - [|cffffcc00Level 4|r]"
-    },
-    {
       "Level": 1,
       "Id": "aub1",
       "Type": 3,
       "Value": "Each enemy air unit in a target area has a 75% chance to be bound to the ground for \u003CA0F3,Dur1\u003E seconds. Air units that are successfully ensnared can be attacked as though they were land units."
-    },
-    {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Applies Frost Armor to all friendly unit in a target area for \u003CA13S,DataA2\u003E seconds, granting \u003CA13S,DataB2\u003E bonus armour and slowing units that attack them for 2 seconds."
-    },
-    {
-      "Level": 3,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Applies Frost Armor to all friendly unit in a target area for \u003CA13S,DataA3\u003E seconds, granting \u003CA13S,DataB3\u003E bonus armour and slowing units that attack them for 2 seconds."
-    },
-    {
-      "Level": 4,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Applies Frost Armor to all friendly unit in a target area for \u003CA13S,DataA4\u003E seconds, granting \u003CA13S,DataB4\u003E bonus armour and slowing units that attack them for 2 seconds."
     },
     {
       "Id": "abpx",

--- a/mapdata/WarcraftLegacies/AbilityData/A01U.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A01U.json
@@ -75,11 +75,6 @@
       "Value": "Earth Bind"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTNEarthquake.blp"
-    },
-    {
       "Id": "arpx",
       "Value": 1
     },
@@ -87,16 +82,6 @@
       "Id": "arhk",
       "Type": 3,
       "Value": "W"
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Earth Bind - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Causes the ground to burst, immobilizing and damaging a target enemy temporarily. |n|n|cffffcc00Level 1|r - 25 damage per second for 5 seconds (1 seconds for Heroes). |n|cffffcc00Level 2|r - 30 damage per second for 6 seconds (1.75 seconds for Heroes). |n|cffffcc00Level 3|r - 40 damage per second for 8 seconds (2.50 seconds for Heroes). |n|cffffcc00Level 4|r - 50 damage per second for 10 seconds (3.25 seconds for Heroes)."
     },
     {
       "Id": "atat",

--- a/mapdata/WarcraftLegacies/AbilityData/A02W.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A02W.json
@@ -12,31 +12,7 @@
       "Value": 250
     },
     {
-      "Level": 2,
-      "Id": "aare",
-      "Type": 2,
-      "Value": 100
-    },
-    {
-      "Level": 3,
-      "Id": "aare",
-      "Type": 2,
-      "Value": 130
-    },
-    {
       "Level": 1,
-      "Id": "abuf",
-      "Type": 3,
-      "Value": ""
-    },
-    {
-      "Level": 2,
-      "Id": "abuf",
-      "Type": 3,
-      "Value": ""
-    },
-    {
-      "Level": 3,
       "Id": "abuf",
       "Type": 3,
       "Value": ""
@@ -48,41 +24,7 @@
       "Value": 0
     },
     {
-      "Level": 2,
-      "Id": "acas",
-      "Type": 2,
-      "Value": 0
-    },
-    {
-      "Level": 3,
-      "Id": "acas",
-      "Type": 2,
-      "Value": 0
-    },
-    {
-      "Level": 2,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 12
-    },
-    {
-      "Level": 3,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 12
-    },
-    {
       "Level": 1,
-      "Id": "amcs",
-      "Value": 150
-    },
-    {
-      "Level": 2,
-      "Id": "amcs",
-      "Value": 150
-    },
-    {
-      "Level": 3,
       "Id": "amcs",
       "Value": 150
     },
@@ -94,35 +36,7 @@
       "Value": 0
     },
     {
-      "Level": 2,
-      "Pointer": 1,
-      "Id": "Hfs1",
-      "Type": 2,
-      "Value": -130
-    },
-    {
-      "Level": 3,
-      "Pointer": 1,
-      "Id": "Hfs1",
-      "Type": 2,
-      "Value": -100
-    },
-    {
       "Level": 1,
-      "Pointer": 2,
-      "Id": "Hfs2",
-      "Type": 2,
-      "Value": 1
-    },
-    {
-      "Level": 2,
-      "Pointer": 2,
-      "Id": "Hfs2",
-      "Type": 2,
-      "Value": 1
-    },
-    {
-      "Level": 3,
       "Pointer": 2,
       "Id": "Hfs2",
       "Type": 2,
@@ -136,35 +50,7 @@
       "Value": 0
     },
     {
-      "Level": 2,
-      "Pointer": 3,
-      "Id": "Hfs3",
-      "Type": 2,
-      "Value": 0
-    },
-    {
-      "Level": 3,
-      "Pointer": 3,
-      "Id": "Hfs3",
-      "Type": 2,
-      "Value": 0
-    },
-    {
       "Level": 1,
-      "Pointer": 5,
-      "Id": "Hfs5",
-      "Type": 2,
-      "Value": 1
-    },
-    {
-      "Level": 2,
-      "Pointer": 5,
-      "Id": "Hfs5",
-      "Type": 2,
-      "Value": 1
-    },
-    {
-      "Level": 3,
       "Pointer": 5,
       "Id": "Hfs5",
       "Type": 2,
@@ -176,20 +62,6 @@
       "Id": "Hfs6",
       "Type": 2,
       "Value": 0
-    },
-    {
-      "Level": 2,
-      "Pointer": 6,
-      "Id": "Hfs6",
-      "Type": 2,
-      "Value": 99999
-    },
-    {
-      "Level": 3,
-      "Pointer": 6,
-      "Id": "Hfs6",
-      "Type": 2,
-      "Value": 99999
     },
     {
       "Level": 1,
@@ -198,52 +70,16 @@
       "Value": 0.001
     },
     {
-      "Level": 2,
-      "Id": "adur",
-      "Type": 2,
-      "Value": 0
-    },
-    {
-      "Level": 3,
-      "Id": "adur",
-      "Type": 2,
-      "Value": 0
-    },
-    {
       "Level": 1,
       "Id": "aeff",
       "Type": 3,
       "Value": ""
     },
     {
-      "Level": 2,
-      "Id": "aeff",
-      "Type": 3,
-      "Value": "X002"
-    },
-    {
-      "Level": 3,
-      "Id": "aeff",
-      "Type": 3,
-      "Value": "X002"
-    },
-    {
       "Level": 1,
       "Id": "ahdu",
       "Type": 2,
       "Value": 0.001
-    },
-    {
-      "Level": 2,
-      "Id": "ahdu",
-      "Type": 2,
-      "Value": 0
-    },
-    {
-      "Level": 3,
-      "Id": "ahdu",
-      "Type": 2,
-      "Value": 0
     },
     {
       "Id": "arac",
@@ -257,34 +93,10 @@
       "Value": 600
     },
     {
-      "Level": 2,
-      "Id": "aran",
-      "Type": 2,
-      "Value": 700
-    },
-    {
-      "Level": 3,
-      "Id": "aran",
-      "Type": 2,
-      "Value": 700
-    },
-    {
       "Level": 1,
       "Id": "atar",
       "Type": 3,
       "Value": "_"
-    },
-    {
-      "Level": 2,
-      "Id": "atar",
-      "Type": 3,
-      "Value": "air,friend,ground,invulnerable,organic,self,vulnerable"
-    },
-    {
-      "Level": 3,
-      "Id": "atar",
-      "Type": 3,
-      "Value": "air,friend,ground,invulnerable,organic,self,vulnerable"
     },
     {
       "Id": "aher",
@@ -360,34 +172,10 @@
       "Value": "Mass Unholy Frenzy"
     },
     {
-      "Level": 2,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Rain of Light - [|cffffcc00Level 2|r]"
-    },
-    {
-      "Level": 3,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Rain of Light - [|cffffcc00Level 2|r]"
-    },
-    {
       "Level": 1,
       "Id": "aub1",
       "Type": 3,
       "Value": "All non-mechanical units in the target area gain Unholy Frenzy, increasing attack rate by 40% but draining them of 2 hit points per second. |nLasts 45 seconds."
-    },
-    {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Heal all friendly units in the target area for 130 hit points."
-    },
-    {
-      "Level": 3,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Heal all friendly units in the target area for 100 hit points."
     },
     {
       "Id": "aeat",

--- a/mapdata/WarcraftLegacies/AbilityData/A02W.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A02W.json
@@ -137,11 +137,6 @@
       "Value": "Mass Unholy Frenzy"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTN_CR_BLOOD.blp"
-    },
-    {
       "Id": "arpx",
       "Value": 3
     },
@@ -149,16 +144,6 @@
       "Id": "arhk",
       "Type": 3,
       "Value": "E"
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Field of Blood - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Conjures a Field of Blood which Heals allied ground units in a target area over time. |n|n|cffffcc00Level 1|r - Heals 150 hit points over 5 seconds, then 10 hit point every 1 seconds for 35 seconds.|n|cffffcc00Level 2|r - Heals 200 hit points over 5 seconds, then 15 hit point every 1 seconds for 35 seconds.|n|cffffcc00Level 3|r - Heals 250 hit points over 5 seconds, then 20 hit point every 1 seconds for 35 seconds.|n"
     },
     {
       "Id": "asat",

--- a/mapdata/WarcraftLegacies/AbilityData/A030.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A030.json
@@ -61,11 +61,6 @@
       "Value": "Call Treants"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTNEnt.blp"
-    },
-    {
       "Id": "arpx",
       "Value": 1
     },
@@ -73,16 +68,6 @@
       "Id": "arhk",
       "Type": 3,
       "Value": "W"
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Call Treant - [|cffffcc00Level %d|r]."
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Summons Treants to battle Malfurion\u0027s enemies. |nLasts \u003CAOsf,Dur1\u003E seconds. |n|n|cffffcc00Level 1|r - 3 Treants.|n|cffffcc00Level 2|r - 4 Treants.|n|cffffcc00Level 3|r - 5 Treants.|n|cffffcc00Level 4|r - 6 Poison Treants."
     },
     {
       "Level": 1,

--- a/mapdata/WarcraftLegacies/AbilityData/A034.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A034.json
@@ -12,66 +12,15 @@
       "Value": 120
     },
     {
-      "Level": 2,
-      "Id": "aare",
-      "Type": 2,
-      "Value": 120
-    },
-    {
-      "Level": 3,
-      "Id": "aare",
-      "Type": 2,
-      "Value": 120
-    },
-    {
-      "Level": 4,
-      "Id": "aare",
-      "Type": 2,
-      "Value": 120
-    },
-    {
       "Level": 1,
       "Id": "acdn",
       "Type": 2,
       "Value": 25
     },
     {
-      "Level": 2,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 9
-    },
-    {
-      "Level": 3,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 9
-    },
-    {
-      "Level": 4,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 9
-    },
-    {
       "Level": 1,
       "Id": "amcs",
       "Value": 145
-    },
-    {
-      "Level": 2,
-      "Id": "amcs",
-      "Value": 80
-    },
-    {
-      "Level": 3,
-      "Id": "amcs",
-      "Value": 80
-    },
-    {
-      "Level": 4,
-      "Id": "amcs",
-      "Value": 80
     },
     {
       "Level": 1,
@@ -81,49 +30,7 @@
       "Value": 150
     },
     {
-      "Level": 2,
-      "Pointer": 1,
-      "Id": "Ncs1",
-      "Type": 2,
-      "Value": 400
-    },
-    {
-      "Level": 3,
-      "Pointer": 1,
-      "Id": "Ncs1",
-      "Type": 2,
-      "Value": 500
-    },
-    {
-      "Level": 4,
-      "Pointer": 1,
-      "Id": "Ncs1",
-      "Type": 2,
-      "Value": 600
-    },
-    {
       "Level": 1,
-      "Pointer": 2,
-      "Id": "Ncs2",
-      "Type": 2,
-      "Value": 1
-    },
-    {
-      "Level": 2,
-      "Pointer": 2,
-      "Id": "Ncs2",
-      "Type": 2,
-      "Value": 1
-    },
-    {
-      "Level": 3,
-      "Pointer": 2,
-      "Id": "Ncs2",
-      "Type": 2,
-      "Value": 1
-    },
-    {
-      "Level": 4,
       "Pointer": 2,
       "Id": "Ncs2",
       "Type": 2,
@@ -136,24 +43,6 @@
       "Value": 2
     },
     {
-      "Level": 2,
-      "Pointer": 3,
-      "Id": "Ncs3",
-      "Value": 3
-    },
-    {
-      "Level": 3,
-      "Pointer": 3,
-      "Id": "Ncs3",
-      "Value": 4
-    },
-    {
-      "Level": 4,
-      "Pointer": 3,
-      "Id": "Ncs3",
-      "Value": 5
-    },
-    {
       "Level": 1,
       "Pointer": 4,
       "Id": "Ncs4",
@@ -161,27 +50,6 @@
       "Value": 900
     },
     {
-      "Level": 2,
-      "Pointer": 4,
-      "Id": "Ncs4",
-      "Type": 2,
-      "Value": 1200
-    },
-    {
-      "Level": 3,
-      "Pointer": 4,
-      "Id": "Ncs4",
-      "Type": 2,
-      "Value": 1500
-    },
-    {
-      "Level": 4,
-      "Pointer": 4,
-      "Id": "Ncs4",
-      "Type": 2,
-      "Value": 1800
-    },
-    {
       "Level": 1,
       "Pointer": 5,
       "Id": "Ncs5",
@@ -189,49 +57,7 @@
       "Value": 0
     },
     {
-      "Level": 2,
-      "Pointer": 5,
-      "Id": "Ncs5",
-      "Type": 2,
-      "Value": 0
-    },
-    {
-      "Level": 3,
-      "Pointer": 5,
-      "Id": "Ncs5",
-      "Type": 2,
-      "Value": 0
-    },
-    {
-      "Level": 4,
-      "Pointer": 5,
-      "Id": "Ncs5",
-      "Type": 2,
-      "Value": 0
-    },
-    {
       "Level": 1,
-      "Pointer": 6,
-      "Id": "Ncs6",
-      "Type": 2,
-      "Value": 1.5
-    },
-    {
-      "Level": 2,
-      "Pointer": 6,
-      "Id": "Ncs6",
-      "Type": 2,
-      "Value": 1.5
-    },
-    {
-      "Level": 3,
-      "Pointer": 6,
-      "Id": "Ncs6",
-      "Type": 2,
-      "Value": 1.5
-    },
-    {
-      "Level": 4,
       "Pointer": 6,
       "Id": "Ncs6",
       "Type": 2,
@@ -252,43 +78,7 @@
       "Value": 1000
     },
     {
-      "Level": 2,
-      "Id": "aran",
-      "Type": 2,
-      "Value": 1200
-    },
-    {
-      "Level": 3,
-      "Id": "aran",
-      "Type": 2,
-      "Value": 1200
-    },
-    {
-      "Level": 4,
-      "Id": "aran",
-      "Type": 2,
-      "Value": 1200
-    },
-    {
       "Level": 1,
-      "Id": "atar",
-      "Type": 3,
-      "Value": "enemies,ground,neutral"
-    },
-    {
-      "Level": 2,
-      "Id": "atar",
-      "Type": 3,
-      "Value": "enemies,ground,neutral"
-    },
-    {
-      "Level": 3,
-      "Id": "atar",
-      "Type": 3,
-      "Value": "enemies,ground,neutral"
-    },
-    {
-      "Level": 4,
       "Id": "atar",
       "Type": 3,
       "Value": "enemies,ground,neutral"
@@ -367,46 +157,10 @@
       "Value": "Arcane Bombardment"
     },
     {
-      "Level": 2,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Arcane Bombardment - [|cffffcc00Level 2|r]"
-    },
-    {
-      "Level": 3,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Arcane Bombardment - [|cffffcc00Level 3|r]"
-    },
-    {
-      "Level": 4,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Arcane Bombardment - [|cffffcc00Level 4|r]"
-    },
-    {
       "Level": 1,
       "Id": "aub1",
       "Type": 3,
       "Value": "Bombards an area with arcane missiles, dealing up to 150 damage to nearby enemy land units and stunning them for 1 seconds."
-    },
-    {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Bombards an area with arcane missiles, dealing up to 400 damage to nearby enemy land units and stunning them for 1 seconds."
-    },
-    {
-      "Level": 3,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Bombards an area with arcane missiles, dealing up to 500 damage to nearby enemy land units and stunning them for 1 seconds."
-    },
-    {
-      "Level": 4,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Bombards an area with arcane missiles, dealing up to 600 damage to nearby enemy land units and stunning them for 1 seconds."
     }
   ]
 }

--- a/mapdata/WarcraftLegacies/AbilityData/A034.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A034.json
@@ -127,11 +127,6 @@
       "Value": "Arcane Bombardment"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTNStarfall.blp"
-    },
-    {
       "Id": "arpx",
       "Value": 0
     },
@@ -139,16 +134,6 @@
       "Id": "arhk",
       "Type": 3,
       "Value": "Q"
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Arcane Bombardment - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Bombards an area with arcane missile, stunning enemy land units for 1 second and damaging them. 1200 range. |n|n|cffffcc00Level 1|r - 300 total damage.|n|cffffcc00Level 2|r - 400 total damage.|n|cffffcc00Level 3|r - 500 total damage.|n|cffffcc00Level 4|r - 600 total damage."
     },
     {
       "Level": 1,

--- a/mapdata/WarcraftLegacies/AbilityData/A043.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A043.json
@@ -65,11 +65,6 @@
       "Value": "Q"
     },
     {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "|cff7777aaHoly Light|r |cff7777aa[E]|r"
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A04B.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A04B.json
@@ -63,16 +63,6 @@
       "Value": "Demon Call"
     },
     {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Demoncall"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Opens a portal, allowing demons to step through and do the Caster\u0027s bidding."
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A04M.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A04M.json
@@ -45,11 +45,6 @@
       "Value": "(Frostmourne)"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTNFrostMourne.blp"
-    },
-    {
       "Id": "arpx",
       "Value": 0
     },
@@ -57,16 +52,6 @@
       "Id": "arhk",
       "Type": 3,
       "Value": "T"
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn |cffffcc00T|rhe Power of Frostmourne - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Frostmourne gives the power for Arthas to hit multiple enemies with one swing of his sword .|n|n|cffffcc00Level 1|r - 25% of damage is splash. |n|cffffcc00Level 2|r - 40% of damage is splash. |n|cffffcc00Level 3|r - 55% of damage is splash."
     },
     {
       "Level": 1,

--- a/mapdata/WarcraftLegacies/AbilityData/A05N.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A05N.json
@@ -101,11 +101,6 @@
       "Value": "W"
     },
     {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Sprays waves of healing mist that heal friendly units in a target area. |n|n|cffffcc00Level 1|r - \u003CA0KN,DataF1\u003E waves at \u003CA0KN,DataA1\u003E hit points healed each. |n|cffffcc00Level 2|r - \u003CA0KN,DataF2\u003E waves at \u003CA0KN,DataA2\u003E hit points healed each. |n|cffffcc00Level 3|r - \u003CA0KN,DataF3\u003E waves at \u003CA0KN,DataA3\u003E hit points healed each."
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A05X.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A05X.json
@@ -83,11 +83,6 @@
       "Value": "W"
     },
     {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "The Crypt Lord forms barbed layers of chitinous armor that increases its defense and returns damage to enemy melee attackers.  |n|n|cffffcc00Level 1|r - \u003CAUts,DataA1,%\u003E% damage returned, \u003CAUts,DataC1\u003E bonus armor. |n|cffffcc00Level 2|r -  \u003CAUts,DataA2,%\u003E% damage returned, \u003CAUts,DataC2\u003E bonus armor. |n|cffffcc00Level 3|r -  \u003CAUts,DataA3,%\u003E% damage returned, \u003CAUts,DataC3\u003E bonus armor.  |n|cffffcc00Level 4|r -  \u003CAUts,DataA4,%\u003E% damage returned, \u003CAUts,DataC4\u003E bonus armor.  |n|cffffcc00Level 5|r -  \u003CAUts,DataA5,%\u003E% damage returned, \u003CAUts,DataC5\u003E bonus armor.  "
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A06G.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A06G.json
@@ -133,11 +133,6 @@
       "Value": "Hail of Arrows"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTNManaFlare.blp"
-    },
-    {
       "Id": "arpx",
       "Value": 0
     },
@@ -145,16 +140,6 @@
       "Id": "arhk",
       "Type": 3,
       "Value": "Q"
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Arcane Bombardment (|cffffff00Q|r)"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Bombards an area with arcane missile, stunning enemy land units for 1 second and damaging them. 1200 range. |n|n|cffffcc00Level 1|r - 300 total damage.|n|cffffcc00Level 2|r - 400 total damage.|n|cffffcc00Level 3|r - 500 total damage.|n|cffffcc00Level 4|r - 600 total damage."
     },
     {
       "Level": 1,

--- a/mapdata/WarcraftLegacies/AbilityData/A06L.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A06L.json
@@ -29,11 +29,6 @@
       "Value": "D"
     },
     {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Mana Shield"
-    },
-    {
       "Id": "abpx",
       "Value": 1
     },
@@ -58,11 +53,6 @@
       "Id": "auhk",
       "Type": 3,
       "Value": "D"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Creates a shield that absorbs damage by using the hero\u0027s mana. |n|n|cffffcc00Level 1|r - \u003CANms,DataA1\u003E damage per point of mana. |n|cffffcc00Level 2|r - \u003CANms,DataA2\u003E damage per point of mana. |n|cffffcc00Level 3|r - \u003CANms,DataA3\u003E damage per point of mana. |n|cffffcc00Level 3|r - \u003CANms,DataA4\u003E damage per point of mana."
     },
     {
       "Level": 1,

--- a/mapdata/WarcraftLegacies/AbilityData/A06L.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A06L.json
@@ -6,27 +6,6 @@
   ],
   "Modifications": [
     {
-      "Level": 2,
-      "Pointer": 1,
-      "Id": "Nms1",
-      "Type": 2,
-      "Value": 4
-    },
-    {
-      "Level": 3,
-      "Pointer": 1,
-      "Id": "Nms1",
-      "Type": 2,
-      "Value": 6
-    },
-    {
-      "Level": 4,
-      "Pointer": 1,
-      "Id": "Nms1",
-      "Type": 2,
-      "Value": 8
-    },
-    {
       "Id": "arac",
       "Type": 3,
       "Value": "human"
@@ -48,18 +27,6 @@
       "Id": "arhk",
       "Type": 3,
       "Value": "D"
-    },
-    {
-      "Level": 4,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Activate Mana Shield - [|cffffcc00Level 4|r]"
-    },
-    {
-      "Level": 4,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Activates a shield that absorbs \u003CANms,DataA4\u003E damage per point of mana."
     },
     {
       "Id": "aret",
@@ -96,24 +63,6 @@
       "Id": "arut",
       "Type": 3,
       "Value": "Creates a shield that absorbs damage by using the hero\u0027s mana. |n|n|cffffcc00Level 1|r - \u003CANms,DataA1\u003E damage per point of mana. |n|cffffcc00Level 2|r - \u003CANms,DataA2\u003E damage per point of mana. |n|cffffcc00Level 3|r - \u003CANms,DataA3\u003E damage per point of mana. |n|cffffcc00Level 3|r - \u003CANms,DataA4\u003E damage per point of mana."
-    },
-    {
-      "Level": 2,
-      "Id": "aut1",
-      "Type": 3,
-      "Value": "Deactivate Mana Shield"
-    },
-    {
-      "Level": 3,
-      "Id": "aut1",
-      "Type": 3,
-      "Value": "Deactivate Mana Shield"
-    },
-    {
-      "Level": 4,
-      "Id": "aut1",
-      "Type": 3,
-      "Value": "Deactivate Mana Shield"
     },
     {
       "Level": 1,

--- a/mapdata/WarcraftLegacies/AbilityData/A07D.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A07D.json
@@ -117,11 +117,6 @@
       "Value": "Portal to Black Temple"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTNWarpPortal.blp"
-    },
-    {
       "Id": "arpx",
       "Value": 3
     },
@@ -129,16 +124,6 @@
       "Id": "arhk",
       "Type": 3,
       "Value": "R"
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Slipstream - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Opens a two-way portal to the target location. The portal becomes usable after 5 seconds, and closes 10 seconds after the caster stops channeling.|n|n|cffffcc00Level 1|r - \u003CA00D,Rng1\u003E range. |n|cffffcc00Level 2|r - \u003CA00D,Rng2\u003E range. |n|cffffcc00Level 3|r - \u003CA00D,Rng3\u003E range."
     },
     {
       "Id": "atat",

--- a/mapdata/WarcraftLegacies/AbilityData/A07D.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A07D.json
@@ -12,43 +12,7 @@
       "Value": 65
     },
     {
-      "Level": 2,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 45
-    },
-    {
-      "Level": 3,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 45
-    },
-    {
-      "Level": 2,
-      "Id": "amcs",
-      "Value": 250
-    },
-    {
-      "Level": 3,
-      "Id": "amcs",
-      "Value": 350
-    },
-    {
       "Level": 1,
-      "Pointer": 1,
-      "Id": "Ncl1",
-      "Type": 2,
-      "Value": 300
-    },
-    {
-      "Level": 2,
-      "Pointer": 1,
-      "Id": "Ncl1",
-      "Type": 2,
-      "Value": 300
-    },
-    {
-      "Level": 3,
       "Pointer": 1,
       "Id": "Ncl1",
       "Type": 2,
@@ -61,51 +25,13 @@
       "Value": 17
     },
     {
-      "Level": 2,
-      "Pointer": 3,
-      "Id": "Ncl3",
-      "Value": 17
-    },
-    {
-      "Level": 3,
-      "Pointer": 3,
-      "Id": "Ncl3",
-      "Value": 17
-    },
-    {
       "Level": 1,
       "Pointer": 5,
       "Id": "Ncl5",
       "Value": 0
     },
     {
-      "Level": 2,
-      "Pointer": 5,
-      "Id": "Ncl5",
-      "Value": 0
-    },
-    {
-      "Level": 3,
-      "Pointer": 5,
-      "Id": "Ncl5",
-      "Value": 0
-    },
-    {
       "Level": 1,
-      "Pointer": 6,
-      "Id": "Ncl6",
-      "Type": 3,
-      "Value": "corrosivebreath"
-    },
-    {
-      "Level": 2,
-      "Pointer": 6,
-      "Id": "Ncl6",
-      "Type": 3,
-      "Value": "corrosivebreath"
-    },
-    {
-      "Level": 3,
       "Pointer": 6,
       "Id": "Ncl6",
       "Type": 3,
@@ -123,31 +49,7 @@
       "Value": 200
     },
     {
-      "Level": 2,
-      "Id": "aran",
-      "Type": 2,
-      "Value": 6000
-    },
-    {
-      "Level": 3,
-      "Id": "aran",
-      "Type": 2,
-      "Value": 9000
-    },
-    {
       "Level": 1,
-      "Pointer": 2,
-      "Id": "Ncl2",
-      "Value": 2
-    },
-    {
-      "Level": 2,
-      "Pointer": 2,
-      "Id": "Ncl2",
-      "Value": 2
-    },
-    {
-      "Level": 3,
       "Pointer": 2,
       "Id": "Ncl2",
       "Value": 2
@@ -250,34 +152,10 @@
       "Value": "Portal to Black Temple"
     },
     {
-      "Level": 2,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Slipstream - [|cffffcc00Level 2|r]"
-    },
-    {
-      "Level": 3,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Slipstream - [|cffffcc00Level 3|r]"
-    },
-    {
       "Level": 1,
       "Id": "aub1",
       "Type": 3,
       "Value": "Opens a two-way portal to Black Temple at the target location. The portal becomes usable after 20 seconds, and closes 15 seconds after the caster stops channeling."
-    },
-    {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Opens a two-way portal to the target location within a range of \u003CA00D,Rng2\u003E. The portal becomes usable after 5 seconds, and closes 20 seconds after the caster stops channeling."
-    },
-    {
-      "Level": 3,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Opens a two-way portal to the target location within a range of \u003CA00D,Rng3\u003E. The portal becomes usable after 5 seconds, and closes 30 seconds after the caster stops channeling."
     }
   ]
 }

--- a/mapdata/WarcraftLegacies/AbilityData/A082.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A082.json
@@ -62,11 +62,6 @@
       "Value": "W"
     },
     {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Reveals the area of the map that it is cast upon. Also reveals invisible units. |n|n|cffffcc00Level 1|r - Reveals a small area for \u003CAOfs,Cost1\u003E mana. |n|cffffcc00Level 2|r - Reveals a large area for \u003CAOfs,Cost2\u003E mana. |n|cffffcc00Level 3|r - Reveals a very large area for \u003CAOfs,Cost3\u003E mana.|n|cffffcc00Level 4|r - Reveals a huge area for \u003CAOfs,Cost4\u003E mana.|n|cffffcc00Level 5|r - Reveals a massive area for \u003CAOfs,Cost5\u003E mana."
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A08X.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A08X.json
@@ -71,24 +71,9 @@
       "Value": "Aura of Dread"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTNRegenerationAura.blp"
-    },
-    {
       "Id": "arhk",
       "Type": 3,
       "Value": "E"
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Aura of Dread - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Decreases armor of nearby enemy units in 600 AOE. |n|n|cffffcc00Level 1|r - Decreases armor by 1.5. |n|cffffcc00Level 2|r - Decreases armor by 3. |n|cffffcc00Level 3|r - Decreases armor by 4.5. |n|cffffcc00Level 4|r - Decreases armor by 6."
     },
     {
       "Id": "atat",

--- a/mapdata/WarcraftLegacies/AbilityData/A08X.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A08X.json
@@ -12,70 +12,13 @@
       "Value": 700
     },
     {
-      "Level": 2,
-      "Id": "aare",
-      "Type": 2,
-      "Value": 600
-    },
-    {
-      "Level": 3,
-      "Id": "aare",
-      "Type": 2,
-      "Value": 600
-    },
-    {
-      "Level": 4,
-      "Id": "aare",
-      "Type": 2,
-      "Value": 600
-    },
-    {
       "Level": 1,
       "Id": "abuf",
       "Type": 3,
       "Value": "B08P"
     },
     {
-      "Level": 2,
-      "Id": "abuf",
-      "Type": 3,
-      "Value": "B08P"
-    },
-    {
-      "Level": 3,
-      "Id": "abuf",
-      "Type": 3,
-      "Value": "B08P"
-    },
-    {
-      "Level": 4,
-      "Id": "abuf",
-      "Type": 3,
-      "Value": "B08P"
-    },
-    {
       "Level": 1,
-      "Pointer": 1,
-      "Id": "Had1",
-      "Type": 2,
-      "Value": -6
-    },
-    {
-      "Level": 2,
-      "Pointer": 1,
-      "Id": "Had1",
-      "Type": 2,
-      "Value": -3
-    },
-    {
-      "Level": 3,
-      "Pointer": 1,
-      "Id": "Had1",
-      "Type": 2,
-      "Value": -4.5
-    },
-    {
-      "Level": 4,
       "Pointer": 1,
       "Id": "Had1",
       "Type": 2,
@@ -104,24 +47,6 @@
     },
     {
       "Level": 1,
-      "Id": "atar",
-      "Type": 3,
-      "Value": "air,enemies,ground,invulnerable,vulnerable"
-    },
-    {
-      "Level": 2,
-      "Id": "atar",
-      "Type": 3,
-      "Value": "air,enemies,ground,invulnerable,vulnerable"
-    },
-    {
-      "Level": 3,
-      "Id": "atar",
-      "Type": 3,
-      "Value": "air,enemies,ground,invulnerable,vulnerable"
-    },
-    {
-      "Level": 4,
       "Id": "atar",
       "Type": 3,
       "Value": "air,enemies,ground,invulnerable,vulnerable"
@@ -177,43 +102,7 @@
       "Value": "Aura of Dread"
     },
     {
-      "Level": 2,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Aura of Dread - [|cffffcc00Level 2|r]"
-    },
-    {
-      "Level": 3,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Aura of Dread - [|cffffcc00Level 3|r]"
-    },
-    {
-      "Level": 4,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Aura of Dread - [|cffffcc00Level 4|r]"
-    },
-    {
       "Level": 1,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Decreases armor of nearby enemy units in 600 AOE by 6."
-    },
-    {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Decreases armor of nearby enemy units in 600 AOE by 3."
-    },
-    {
-      "Level": 3,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Decreases armor of nearby enemy units in 600 AOE by 4.5."
-    },
-    {
-      "Level": 4,
       "Id": "aub1",
       "Type": 3,
       "Value": "Decreases armor of nearby enemy units in 600 AOE by 6."

--- a/mapdata/WarcraftLegacies/AbilityData/A08Z.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A08Z.json
@@ -6,22 +6,6 @@
   ],
   "Modifications": [
     {
-      "Level": 2,
-      "Id": "amcs",
-      "Value": 40
-    },
-    {
-      "Level": 4,
-      "Id": "amcs",
-      "Value": 60
-    },
-    {
-      "Level": 4,
-      "Pointer": 5,
-      "Id": "Ucb5",
-      "Value": 12
-    },
-    {
       "Id": "alev",
       "Value": 1
     },
@@ -91,34 +75,10 @@
       "Value": "The Crypt Lord progenerates Carrion Beetle from a target corpse to attack the Crypt Lord\u0027s enemies. Beetles are permanent. |n|n|cffffcc00Level 1|r - Spawns a level 1 Carrion Beetle. Max 6 Beetles. |n|cffffcc00Level 2|r - Spawns a level 2 Carrion Beetle. Max 6 Beetles. |n|cffffcc00Level 3|r - Spawns a level 3 Dire Carrion Beetle. Max 6 Beetles. |n|cffffcc00Level 4|r - Spawns a level 3 Dire Carrion Beetle. Max 12 Beetles."
     },
     {
-      "Level": 4,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Carrion Beetles - [|cffffcc00Level 4|r]"
-    },
-    {
       "Level": 1,
       "Id": "aub1",
       "Type": 3,
       "Value": "The Druid summons 3 spiders from nearby. The spiders are untargetable and uncontrollable and will attack enemies in proximity."
-    },
-    {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "The Crypt Lord progenerates Carrion Beetle from a target corpse to attack the Crypt Lord\u0027s enemies. Beetles are permanent. |n|n| Spawns a level 2 Carrion Beetle. Max 6 Beetles. |n|n| Got Spiked Carapace, Acid Attack -7 and Burrow."
-    },
-    {
-      "Level": 3,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "The Crypt Lord progenerates Carrion Beetle from a target corpse to attack the Crypt Lord\u0027s enemies. Beetles are permanent. |n|n| Spawns a level 3 Dire Carrion Beetle. Max 6 Beetles. |n|n| Got Spiked Carapace, Acid Attack -10, Burrow and Spawn Beetles."
-    },
-    {
-      "Level": 4,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "The Crypt Lord progenerates Carrion Beetle from a target corpse to attack the Crypt Lord\u0027s enemies. Beetles are permanent. |n|nSpawns a level 3 Dire Carrion Beetle. Max 12 Beetles. |n|nGot Spiked Carapace, Acid Attack -10, Burrow and Spawn Beetles."
     },
     {
       "Id": "anam",

--- a/mapdata/WarcraftLegacies/AbilityData/A08Z.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A08Z.json
@@ -70,11 +70,6 @@
       "Value": "E"
     },
     {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "The Crypt Lord progenerates Carrion Beetle from a target corpse to attack the Crypt Lord\u0027s enemies. Beetles are permanent. |n|n|cffffcc00Level 1|r - Spawns a level 1 Carrion Beetle. Max 6 Beetles. |n|cffffcc00Level 2|r - Spawns a level 2 Carrion Beetle. Max 6 Beetles. |n|cffffcc00Level 3|r - Spawns a level 3 Dire Carrion Beetle. Max 6 Beetles. |n|cffffcc00Level 4|r - Spawns a level 3 Dire Carrion Beetle. Max 12 Beetles."
-    },
-    {
       "Level": 1,
       "Id": "aub1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A0A0.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0A0.json
@@ -113,11 +113,6 @@
       "Value": "Dark Pact"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTNHolyShower.blp"
-    },
-    {
       "Id": "arpx",
       "Value": 1
     },
@@ -129,16 +124,6 @@
       "Id": "arhk",
       "Type": 3,
       "Value": "R"
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "[|cffffcc00R|r] Learn Solar Judgement - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Targets an area for solar bombardment, carpeting it with 28 bolts over the course of 14 seconds. Each bolt deals damage to enemy units and heals non-Undead allies for 150% of that amount. Undead enemies take 10% additional damage.  |n|n|cffffcc00Level 1|r - Each bolt deals 40 damage.|n|cffffcc00Level 2|r - Each bolt deals 60 damage. |n|cffffcc00Level 3|r - Each bolt deals 80 damage."
     },
     {
       "Level": 1,

--- a/mapdata/WarcraftLegacies/AbilityData/A0AW.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0AW.json
@@ -80,21 +80,6 @@
       "Value": "War Stomp"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTNWarStomp.blp"
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn War Stomp - [|cffffcc00Level %d|r]."
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Slams the ground, stunning and damaging nearby enemy land units. |n|n|cffffcc00Level 1|r - \u003CAOw2,DataA1\u003E damage, \u003CAOw2,Dur1\u003E second stun. |n|cffffcc00Level 2|r - \u003CAOw2,DataA2\u003E damage, \u003CAOw2,Dur2\u003E second stun. |n|cffffcc00Level 3|r - \u003CAOw2,DataA3\u003E damage, \u003CAOw2,Dur3\u003E second stun. |n|cffffcc00Level 4|r - \u003CAOw2,DataA4\u003E damage, \u003CAOw2,Dur4\u003E second stun."
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A0B2.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0B2.json
@@ -46,11 +46,6 @@
       "Value": "E"
     },
     {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Gives additional armor to nearby friendly units. |n|n|cffffcc00Level 1|r - Increases base armor by 1.5. |n|cffffcc00Level 2|r - Increases base armor by 3. |n|cffffcc00Level 3|r - Increases base armor by 4.5. |n|cffffcc00Level 4|r - Increases base armor by 6."
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A0BA.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0BA.json
@@ -66,16 +66,6 @@
       "Value": "Q"
     },
     {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Mana Burn (|cffffcc00Q|r) - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Sends a bolt of negative energy that burns a target enemy unit\u0027s mana. Burned mana combusts, dealing damage to the target equal to the amount of mana burned. |n|n|cffffcc00Level 1|r - Burns up to 100 mana. |n|cffffcc00Level 2|r - Burns up to 160 mana. |n|cffffcc00Level 3|r - Burns up to 220 mana.|n|cffffcc00Level 4|r - Burns up to 280 mana.|n|cffffcc00Level 5|r - Burns up to 340 mana."
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A0BB.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0BB.json
@@ -40,16 +40,6 @@
       "Value": "E"
     },
     {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Immolation"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Engulfs the Demon Hunter in flames, causing 20 damage per second to nearby enemy land units. |nDrains mana until deactivated. |n|n"
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A0BV.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0BV.json
@@ -88,11 +88,6 @@
       "Value": "W"
     },
     {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Summons \u003CAOsf,DataB1\u003E Spirit Wolves to fight the Far Seer\u0027s enemies. |nLasts \u003CAOsf,Dur1\u003E seconds. |n|n|cffffcc00Level 1|r - \u003Cosw1,realHP\u003E hit points, \u003Cosw1,mindmg1\u003E - \u003Cosw1,maxdmg1\u003E damage. 2 wolves summoned.|n|cffffcc00Level 2|r - \u003Cosw2,realHP\u003E hit points, \u003Cosw2,mindmg1\u003E - \u003Cosw2,maxdmg1\u003E damage and Critical Strike. 2 wolves summoned.|n|cffffcc00Level 3|r - \u003Cosw3,realHP\u003E hit points, \u003Cosw3,mindmg1\u003E - \u003Cosw3,maxdmg1\u003E damage and Critical Strike. 2 wolves summoned.|n|cffffcc00Level 4|r - \u003Cosw3,realHP\u003E hit points, \u003Cosw3,mindmg1\u003E - \u003Cosw3,maxdmg1\u003E damage, and Critical Strike. 4 wolves summoned.|n|cffffcc00Level 5|r - \u003Cosw3,realHP\u003E hit points, \u003Cosw3,mindmg1\u003E - \u003Cosw3,maxdmg1\u003E damage and Critical Strike. 6 wolves summoned.|n"
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A0BY.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0BY.json
@@ -45,16 +45,6 @@
       "Value": "W"
     },
     {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Mana Shield"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Creates a shield that absorbs damage by using the Caster\u0027s mana. |n|n|cffffcc00Level 1|r - 1 damage per point of mana. |n|cffffcc00Level 2|r - 1.5 damage per point of mana. |n|cffffcc00Level 3|r - 2 damage per point of mana. |n|cffffcc00Level 4|r - 2.5 damage per point of mana. |n|cffffcc00Level 5|r - 3 damage per point of mana."
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A0C3.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0C3.json
@@ -38,16 +38,6 @@
       "Value": "W"
     },
     {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Mana Shield"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Creates a shield that absorbs damage by using the Caster\u0027s mana. |n|n|cffffcc00Level 1|r - 1 damage per point of mana. |n|cffffcc00Level 2|r - 1.5 damage per point of mana. |n|cffffcc00Level 3|r - 2 damage per point of mana. |n|cffffcc00Level 4|r - 2.5 damage per point of mana. |n|cffffcc00Level 5|r - 3 damage per point of mana."
-    },
-    {
       "Level": 1,
       "Id": "aub1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A0CN.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0CN.json
@@ -47,16 +47,6 @@
       "Value": "Q"
     },
     {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Entangling Roots (|cffffcc00Q|r) - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Causes roots to burst from the ground, immobilizing, disarming and damaging a target enemy temporarily. |n|n|cffffcc00Level 1|r - \u003CAEer,DataA1\u003E damage per second for \u003CAEer,Dur1\u003E seconds. |n|cffffcc00Level 2|r - \u003CAEer,DataA2\u003E damage per second for \u003CAEer,Dur2\u003E seconds. |n|cffffcc00Level 3|r - \u003CAEer,DataA3\u003E damage per second for \u003CAEer,Dur3\u003E seconds.|n|cffffcc00Level 4|r - \u003CAEer,DataA4\u003E damage per second for \u003CAEer,Dur4\u003E seconds.|n|cffffcc00Level 5|r - \u003CAEer,DataA5\u003E damage per second for \u003CAEer,Dur5\u003E seconds."
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A0CO.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0CO.json
@@ -135,16 +135,6 @@
       "Value": "Q"
     },
     {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Frost Nova (|cffffcc00Q|r) - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Blasts enemy units around a target enemy unit with a wave of damaging frost that slows movement and attack rate. |n|n|cffffcc00Level 1|r - 100 target damage, 50 nova damage. |n|cffffcc00Level 2|r - 100 target damage, 100 nova damage. |n|cffffcc00Level 3|r - 100 target damage, 150 nova damage. |n|cffffcc00Level 4|r - 100 target damage, 200 nova damage. |n|cffffcc00Level 5|r - 100 target damage, 250 nova damage."
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A0CV.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0CV.json
@@ -77,16 +77,6 @@
       "Value": "Q"
     },
     {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn (|cffffcc00Q|r) Pocket Factory - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Creates a factory which automatically constructs Clockwerk Goblins. These artificial Goblins, in addition to being potent attackers, explode upon death, causing damage to nearby enemy units. |n|n|cffffcc00Level 1|r - Explosion does 30 damage.|n|cffffcc00Level 2|r - Explosion does 60 damage.|n|cffffcc00Level 3|r - Explosion does 80 damage. |n|cffffcc00Level 4|r - Explosion does 100 damage.|nFactory lasts 40 seconds."
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A0CX.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0CX.json
@@ -147,11 +147,6 @@
       "Value": "Rain of Light"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTN_CR_BLOOD.blp"
-    },
-    {
       "Id": "arpx",
       "Value": 3
     },
@@ -159,16 +154,6 @@
       "Id": "arhk",
       "Type": 3,
       "Value": "E"
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Field of Blood - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Conjures a Field of Blood which Heals allied ground units in a target area over time. |n|n|cffffcc00Level 1|r - Heals 150 hit points over 5 seconds, then 10 hit point every 1 seconds for 35 seconds.|n|cffffcc00Level 2|r - Heals 200 hit points over 5 seconds, then 15 hit point every 1 seconds for 35 seconds.|n|cffffcc00Level 3|r - Heals 250 hit points over 5 seconds, then 20 hit point every 1 seconds for 35 seconds.|n"
     },
     {
       "Id": "asat",

--- a/mapdata/WarcraftLegacies/AbilityData/A0CX.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0CX.json
@@ -12,34 +12,10 @@
       "Value": 120
     },
     {
-      "Level": 2,
-      "Id": "aare",
-      "Type": 2,
-      "Value": 900
-    },
-    {
-      "Level": 3,
-      "Id": "aare",
-      "Type": 2,
-      "Value": 900
-    },
-    {
       "Level": 1,
       "Id": "abuf",
       "Type": 3,
       "Value": ""
-    },
-    {
-      "Level": 2,
-      "Id": "abuf",
-      "Type": 3,
-      "Value": "B06L"
-    },
-    {
-      "Level": 3,
-      "Id": "abuf",
-      "Type": 3,
-      "Value": "B06L"
     },
     {
       "Level": 1,
@@ -48,43 +24,9 @@
       "Value": 0
     },
     {
-      "Level": 2,
-      "Id": "acas",
-      "Type": 2,
-      "Value": 1
-    },
-    {
-      "Level": 3,
-      "Id": "acas",
-      "Type": 2,
-      "Value": 1
-    },
-    {
-      "Level": 2,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 120
-    },
-    {
-      "Level": 3,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 120
-    },
-    {
       "Level": 1,
       "Id": "amcs",
       "Value": 150
-    },
-    {
-      "Level": 2,
-      "Id": "amcs",
-      "Value": 200
-    },
-    {
-      "Level": 3,
-      "Id": "amcs",
-      "Value": 250
     },
     {
       "Level": 1,
@@ -94,35 +36,7 @@
       "Value": -125
     },
     {
-      "Level": 2,
-      "Pointer": 1,
-      "Id": "Hfs1",
-      "Type": 2,
-      "Value": -40
-    },
-    {
-      "Level": 3,
-      "Pointer": 1,
-      "Id": "Hfs1",
-      "Type": 2,
-      "Value": -50
-    },
-    {
       "Level": 1,
-      "Pointer": 2,
-      "Id": "Hfs2",
-      "Type": 2,
-      "Value": 1
-    },
-    {
-      "Level": 2,
-      "Pointer": 2,
-      "Id": "Hfs2",
-      "Type": 2,
-      "Value": 1
-    },
-    {
-      "Level": 3,
       "Pointer": 2,
       "Id": "Hfs2",
       "Type": 2,
@@ -136,35 +50,7 @@
       "Value": 0
     },
     {
-      "Level": 2,
-      "Pointer": 3,
-      "Id": "Hfs3",
-      "Type": 2,
-      "Value": -15
-    },
-    {
-      "Level": 3,
-      "Pointer": 3,
-      "Id": "Hfs3",
-      "Type": 2,
-      "Value": -20
-    },
-    {
       "Level": 1,
-      "Pointer": 5,
-      "Id": "Hfs5",
-      "Type": 2,
-      "Value": 1
-    },
-    {
-      "Level": 2,
-      "Pointer": 5,
-      "Id": "Hfs5",
-      "Type": 2,
-      "Value": 1
-    },
-    {
-      "Level": 3,
       "Pointer": 5,
       "Id": "Hfs5",
       "Type": 2,
@@ -178,36 +64,10 @@
       "Value": 99999
     },
     {
-      "Level": 2,
-      "Pointer": 6,
-      "Id": "Hfs6",
-      "Type": 2,
-      "Value": 900
-    },
-    {
-      "Level": 3,
-      "Pointer": 6,
-      "Id": "Hfs6",
-      "Type": 2,
-      "Value": 900
-    },
-    {
       "Level": 1,
       "Id": "adur",
       "Type": 2,
       "Value": 0
-    },
-    {
-      "Level": 2,
-      "Id": "adur",
-      "Type": 2,
-      "Value": 35
-    },
-    {
-      "Level": 3,
-      "Id": "adur",
-      "Type": 2,
-      "Value": 35
     },
     {
       "Level": 1,
@@ -216,34 +76,10 @@
       "Value": "X002"
     },
     {
-      "Level": 2,
-      "Id": "aeff",
-      "Type": 3,
-      "Value": "X00F"
-    },
-    {
-      "Level": 3,
-      "Id": "aeff",
-      "Type": 3,
-      "Value": "X00F"
-    },
-    {
       "Level": 1,
       "Id": "ahdu",
       "Type": 2,
       "Value": 0
-    },
-    {
-      "Level": 2,
-      "Id": "ahdu",
-      "Type": 2,
-      "Value": 5
-    },
-    {
-      "Level": 3,
-      "Id": "ahdu",
-      "Type": 2,
-      "Value": 5
     },
     {
       "Id": "arac",
@@ -257,34 +93,10 @@
       "Value": 700
     },
     {
-      "Level": 2,
-      "Id": "aran",
-      "Type": 2,
-      "Value": 650
-    },
-    {
-      "Level": 3,
-      "Id": "aran",
-      "Type": 2,
-      "Value": 650
-    },
-    {
       "Level": 1,
       "Id": "atar",
       "Type": 3,
       "Value": "air,friend,ground,invulnerable,organic,self,vulnerable"
-    },
-    {
-      "Level": 2,
-      "Id": "atar",
-      "Type": 3,
-      "Value": "friend,ground,neutral,self"
-    },
-    {
-      "Level": 3,
-      "Id": "atar",
-      "Type": 3,
-      "Value": "friend,ground,neutral,self"
     },
     {
       "Id": "alev",
@@ -370,34 +182,10 @@
       "Value": "Rain of Light"
     },
     {
-      "Level": 2,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Field of Blood - [|cffffcc00Level 2|r]"
-    },
-    {
-      "Level": 3,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Field of Blood - [|cffffcc00Level 3|r]"
-    },
-    {
       "Level": 1,
       "Id": "aub1",
       "Type": 3,
       "Value": "Heal all friendly units in the target area for 100 hit points."
-    },
-    {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Conjures a Field of Blood which Heals allied ground units in a target area over time. |n|nHeals 200 hit points over 5 seconds, then 15 hit point every 1 seconds for 35 seconds.|n"
-    },
-    {
-      "Level": 3,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Conjures a Field of Blood which Heals allied ground units in a target area over time. |n|cffffcc00|n|rHeals 250 hit points over 5 seconds, then 20 hit point every 1 seconds for 35 seconds."
     },
     {
       "Id": "aeat",

--- a/mapdata/WarcraftLegacies/AbilityData/A0DS.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0DS.json
@@ -50,11 +50,6 @@
       "Value": "(dummy)"
     },
     {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Increases the movement speed and attack rate of nearby friendly units. |n|n|cffffcc00Level 1|r - \u003CAOae,DataA1,%\u003E% movement, \u003CAOae,DataB1,%\u003E% attack. |n|cffffcc00Level 2|r - \u003CAOae,DataA2,%\u003E% movement, \u003CAOae,DataB2,%\u003E% attack. |n|cffffcc00Level 3|r - \u003CAOae,DataA3,%\u003E% movement, \u003CAOae,DataB3,%\u003E% attack.|n|cffffcc00Level 4|r - \u003CAOae,DataA4,%\u003E% movement, \u003CAOae,DataB4,%\u003E% attack."
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A0DW.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0DW.json
@@ -58,11 +58,6 @@
       "Value": "D"
     },
     {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Short distance teleportation that allows the Warden to move in and out of combat. |n|n|cffffcc00Level 1|r - \u003CAEbl,Cool1\u003E second cooldown, \u003CAEbl,Cost1\u003E mana. |n|cffffcc00Level 2|r - \u003CAEbl,Cool2\u003E second cooldown, \u003CAEbl,Cost2\u003E mana. |n|cffffcc00Level 3|r - \u003CAEbl,Cool3\u003E second cooldown, \u003CAEbl,Cost3\u003E mana. |n|cffffcc00Level 4|r - \u003CAEbl,Cool4\u003E second cooldown, \u003CAEbl,Cost4\u003E mana."
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A0E2.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0E2.json
@@ -32,16 +32,6 @@
       "Value": "R"
     },
     {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Evasion"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Gives a percent chance to avoid attacks. |n|n|cffffcc00Level 1|r - \u003CAEev,DataA1,%\u003E% chance that an opponent misses. |n|cffffcc00Level 2|r - \u003CAEev,DataA2,%\u003E% chance that an opponent misses. |n|cffffcc00Level 3|r - \u003CAEev,DataA3,%\u003E% chance that an opponent misses. |n|cffffcc00Level 3|r - 36% chance that an opponent misses. |n|cffffcc00Level 5|r - 42% chance that an opponent misses."
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A0EE.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0EE.json
@@ -122,11 +122,6 @@
       "Value": "Mass Bloodlust"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTNSpell_Shadow_BloodBoil.blp"
-    },
-    {
       "Id": "arpx",
       "Value": 3
     },
@@ -134,16 +129,6 @@
       "Id": "arhk",
       "Type": 3,
       "Value": "R"
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Blood Frenzy - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Greatly increases the attack speed and move speed of units inside the targeted area. |n|n|cffffcc00Level 1|r - 90% increased attack speed, 120% increased movement speed. Lasts 30 seconds. |n|cffffcc00Level 2|r - 110% increased attack speed, 130% increased movement speed. Lasts 30 seconds |n|cffffcc00Level 3|r - 130% increased attack speed, 140% increased movement speed. Lasts 30 seconds"
     },
     {
       "Level": 1,

--- a/mapdata/WarcraftLegacies/AbilityData/A0EP.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0EP.json
@@ -118,11 +118,6 @@
       "Value": "Summon Granite Golems"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTNMind Crush.blp"
-    },
-    {
       "Id": "arpx",
       "Value": 3
     },
@@ -130,16 +125,6 @@
       "Id": "arhk",
       "Type": 3,
       "Value": "Z"
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Inspire Madness - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Takes control of several random enemy units in the target area. After 30 seconds, each unit controlled this way dies of madness.|n|n|cffffcc00Level 1|r - Controls 6 units. |n|cffffcc00Level 2|r - Controls 10 units. |n|cffffcc00Level 3|r - Controls 14 units."
     },
     {
       "Id": "atat",

--- a/mapdata/WarcraftLegacies/AbilityData/A0F9.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0F9.json
@@ -286,24 +286,9 @@
       "Value": "Resurgent Flame Strike"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTNCosmicFlame.blp"
-    },
-    {
       "Id": "arhk",
       "Type": 3,
       "Value": "Q"
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": ""
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": ""
     },
     {
       "Level": 1,

--- a/mapdata/WarcraftLegacies/AbilityData/A0FO.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0FO.json
@@ -57,11 +57,6 @@
       "Value": "E"
     },
     {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Transfers mana between the Blood Mage and a target. Drains mana from an enemy, or transfers mana to an ally.|n|nSiphon Mana can push the Blood Mage\u0027s mana over its maximum value, though excess mana drains off rapidly if not used.|nLasts \u003CAHdr,Dur1\u003E seconds.|n|n|cffffcc00Level 1|r - \u003CAHdr,DataB1\u003E mana drained per second. |n|cffffcc00Level 2|r - \u003CAHdr,DataB2\u003E mana drained per second. |n|cffffcc00Level 3|r - \u003CAHdr,DataB3\u003E mana drained per second. |n|cffffcc00Level 4|r - \u003CAHdr,DataB4\u003E mana drained per second. |n|cffffcc00Level 5|r - \u003CAHdr,DataB5\u003E mana drained per second."
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A0GA.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0GA.json
@@ -93,11 +93,6 @@
       "Value": "W"
     },
     {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Summons \u003CAOsf,DataB1\u003E Spirit Wolves to fight the Far Seer\u0027s enemies. |nLasts \u003CAOsf,Dur1\u003E seconds. |n|n|cffffcc00Level 1|r - \u003Cosw1,realHP\u003E hit points, \u003Cosw1,mindmg1\u003E - \u003Cosw1,maxdmg1\u003E damage. 2 wolves summoned.|n|cffffcc00Level 2|r - \u003Cosw2,realHP\u003E hit points, \u003Cosw2,mindmg1\u003E - \u003Cosw2,maxdmg1\u003E damage and Critical Strike. 2 wolves summoned.|n|cffffcc00Level 3|r - \u003Cosw3,realHP\u003E hit points, \u003Cosw3,mindmg1\u003E - \u003Cosw3,maxdmg1\u003E damage and Critical Strike. 2 wolves summoned.|n|cffffcc00Level 4|r - \u003Cosw3,realHP\u003E hit points, \u003Cosw3,mindmg1\u003E - \u003Cosw3,maxdmg1\u003E damage, and Critical Strike. 4 wolves summoned.|n|cffffcc00Level 5|r - \u003Cosw3,realHP\u003E hit points, \u003Cosw3,mindmg1\u003E - \u003Cosw3,maxdmg1\u003E damage and Critical Strike. 6 wolves summoned.|n"
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A0GD.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0GD.json
@@ -90,11 +90,6 @@
       "Value": "Summon Garrison"
     },
     {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Summons a water elemental to attack the Archmage\u0027s enemies, has crushing wave. |nLasts \u003CAHwe,Dur1\u003E seconds. |n|n|cffffcc00Attacks land and air units.|r |n|n|cffffcc00Level 1|r - Summons 2 Water Elementals|n|cffffcc00Level 2|r - Summons 3 Water Elementals.|n|cffffcc00Level 3|r - Summons 4 Water Elementals.|n|cffffcc00Level 4|r - Summons 3 Elite Water Elementals.|n|cffffcc00Level 5|r - Summons 4 Elite Water Elementals."
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A0GE.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0GE.json
@@ -103,11 +103,6 @@
       "Value": "W"
     },
     {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Bombards an area with rockets, stunning enemy units for 1 second and damaging nearby enemy units.|n|n|cffffcc00Level 1|r - 45 damage.|n|cffffcc00Level 2|r - 75 damage.|n|cffffcc00Level 3|r - 110 damage.|n|cffffcc00Level 4|r - 150 damage."
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A0GL.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0GL.json
@@ -197,16 +197,6 @@
       "Value": "Q"
     },
     {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Greater Storm Bolt (|cffffcc00Q|r) - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "A magical hammer that is thrown at an enemy unit, causing damage and stunning the target. |n|n|cffffcc00Level 1|r - 250 damage, 4 second stun. 2 second on Heroes.|n|cffffcc00Level 2|r - 300 damage, 5 second stun. 2.5 seconds on Heroes.|n|cffffcc00Level 3|r - 350 damage, 6 second stun. 3 seconds on Heroes.|n|cffffcc00Level 4|r - 400 damage, 7 second stun. 3.5 seconds on Heroes"
-    },
-    {
       "Level": 2,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A0GM.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0GM.json
@@ -119,11 +119,6 @@
       "Value": "For The Horde!"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTNSpell_Shadow_BloodBoil.blp"
-    },
-    {
       "Id": "arpx",
       "Value": 3
     },
@@ -131,16 +126,6 @@
       "Id": "arhk",
       "Type": 3,
       "Value": "R"
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Blood Frenzy - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Greatly increases the attack speed and move speed of units inside the targeted area. |n|n|cffffcc00Level 1|r - 90% increased attack speed, 120% increased movement speed. Lasts 30 seconds. |n|cffffcc00Level 2|r - 110% increased attack speed, 130% increased movement speed. Lasts 30 seconds |n|cffffcc00Level 3|r - 130% increased attack speed, 140% increased movement speed. Lasts 30 seconds"
     },
     {
       "Level": 1,

--- a/mapdata/WarcraftLegacies/AbilityData/A0GY.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0GY.json
@@ -36,11 +36,6 @@
       "Value": "W"
     },
     {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "The Crypt Lord forms barbed layers of chitinous armor that increases its defense and returns damage to enemy melee attackers.  |n|n|cffffcc00Level 1|r - \u003CAUts,DataA1,%\u003E% damage returned, \u003CAUts,DataC1\u003E bonus armor. |n|cffffcc00Level 2|r -  \u003CAUts,DataA2,%\u003E% damage returned, \u003CAUts,DataC2\u003E bonus armor. |n|cffffcc00Level 3|r -  \u003CAUts,DataA3,%\u003E% damage returned, \u003CAUts,DataC3\u003E bonus armor.  |n|cffffcc00Level 4|r -  \u003CAUts,DataA4,%\u003E% damage returned, \u003CAUts,DataC4\u003E bonus armor.  |n|cffffcc00Level 5|r -  \u003CAUts,DataA5,%\u003E% damage returned, \u003CAUts,DataC5\u003E bonus armor.  "
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A0H0.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0H0.json
@@ -69,11 +69,6 @@
       "Value": "Healing Surge"
     },
     {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "|cff7777aaHoly Light|r |cff7777aa[E]|r"
-    },
-    {
       "Id": "atat",
       "Type": 3,
       "Value": "Abilities\\Spells\\Items\\RitualDagger\\RitualDaggerTarget.mdl"

--- a/mapdata/WarcraftLegacies/AbilityData/A0HA.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0HA.json
@@ -102,16 +102,6 @@
       "Value": "Q"
     },
     {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Healing Spray (|cffffcc00Q|r)  - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Rexxar sprays waves of mists into his allies healing them. |n|n|cffffcc00Level 1|r - 3 waves at 60 hit points healed each. |n|cffffcc00Level 2|r - 4 waves at 65 hit points healed each. |n|cffffcc00Level 3|r - 5 waves at 75 hit points healed each.|n|cffffcc00Level 4|r - 6 waves at 85 hit points healed each.|n|cffffcc00Level 5|r - 7 waves at 100 hit points healed each."
-    },
-    {
       "Id": "asat",
       "Type": 3,
       "Value": "Abilities\\Spells\\Other\\TinkerRocket\\TinkerRocketMissile.mdl"

--- a/mapdata/WarcraftLegacies/AbilityData/A0HL.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0HL.json
@@ -51,16 +51,6 @@
       "Value": 0
     },
     {
-      "Id": "aret",
-      "Type": 3,
-      "Value": ""
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "In the pressence of Feathermoon Stronghold nearby friendly units have their attack increased by \u003CAEar,DataA1,%\u003E%."
-    },
-    {
       "Id": "atat",
       "Type": 3,
       "Value": ""

--- a/mapdata/WarcraftLegacies/AbilityData/A0HN.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0HN.json
@@ -70,23 +70,8 @@
       "Value": "Naval Aura"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": ""
-    },
-    {
       "Id": "arpx",
       "Value": 0
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": ""
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": ""
     },
     {
       "Id": "atat",

--- a/mapdata/WarcraftLegacies/AbilityData/A0HO.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0HO.json
@@ -100,23 +100,8 @@
       "Value": "Auberdine Navy"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTNNightElfBattleCruiser.blp"
-    },
-    {
       "Id": "arpx",
       "Value": 0
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": ""
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": ""
     },
     {
       "Level": 1,

--- a/mapdata/WarcraftLegacies/AbilityData/A0HT.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0HT.json
@@ -11,51 +11,22 @@
       "Value": 30
     },
     {
-      "Level": 2,
-      "Id": "amcs",
-      "Value": 100
-    },
-    {
       "Level": 1,
       "Pointer": 1,
       "Id": "Rai1",
       "Value": 1
     },
     {
-      "Level": 2,
-      "Pointer": 1,
-      "Id": "Rai1",
-      "Value": 2
-    },
-    {
-      "Level": 2,
-      "Pointer": 2,
-      "Id": "Rai2",
-      "Value": 0
-    },
-    {
       "Level": 1,
       "Id": "adur",
       "Type": 2,
       "Value": 10
     },
     {
-      "Level": 2,
-      "Id": "adur",
-      "Type": 2,
-      "Value": 70
-    },
-    {
       "Level": 1,
       "Id": "ahdu",
       "Type": 2,
       "Value": 10
-    },
-    {
-      "Level": 2,
-      "Id": "ahdu",
-      "Type": 2,
-      "Value": 70
     },
     {
       "Id": "alev",
@@ -106,18 +77,6 @@
       "Id": "atp1",
       "Type": 3,
       "Value": "Cycle of Rebirth"
-    },
-    {
-      "Level": 2,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Raise Dead - [|cffffcc00Level 2|r]"
-    },
-    {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Raises \u003CArai,DataA2\u003E skeletons from a corpse for \u003CArai,Dur2\u003E seconds."
     },
     {
       "Id": "auhk",

--- a/mapdata/WarcraftLegacies/AbilityData/A0IK.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0IK.json
@@ -204,11 +204,6 @@
       "Value": "Mass Ice Lance"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTNFrostBolt.blp"
-    },
-    {
       "Id": "arpx",
       "Value": 1
     },
@@ -216,16 +211,6 @@
       "Id": "arhk",
       "Type": 3,
       "Value": "W"
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Ice Lance - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Sends a lance of frost magic at an enemy unit, causing damage and stunning the target. |n|n|cffffcc00Level 1|r - 150 damage, 4 second stun. |n|cffffcc00Level 2|r - 225 damage, 5 second stun. |n|cffffcc00Level 3|r - 300 damage, 6 second stun. |n|cffffcc00Level 4|r - 375 damage, 7 second stun."
     },
     {
       "Level": 1,

--- a/mapdata/WarcraftLegacies/AbilityData/A0JQ.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0JQ.json
@@ -12,31 +12,7 @@
       "Value": 120
     },
     {
-      "Level": 2,
-      "Id": "aare",
-      "Type": 2,
-      "Value": 100
-    },
-    {
-      "Level": 3,
-      "Id": "aare",
-      "Type": 2,
-      "Value": 130
-    },
-    {
       "Level": 1,
-      "Id": "abuf",
-      "Type": 3,
-      "Value": ""
-    },
-    {
-      "Level": 2,
-      "Id": "abuf",
-      "Type": 3,
-      "Value": ""
-    },
-    {
-      "Level": 3,
       "Id": "abuf",
       "Type": 3,
       "Value": ""
@@ -48,41 +24,7 @@
       "Value": 0
     },
     {
-      "Level": 2,
-      "Id": "acas",
-      "Type": 2,
-      "Value": 0
-    },
-    {
-      "Level": 3,
-      "Id": "acas",
-      "Type": 2,
-      "Value": 0
-    },
-    {
-      "Level": 2,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 12
-    },
-    {
-      "Level": 3,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 12
-    },
-    {
       "Level": 1,
-      "Id": "amcs",
-      "Value": 150
-    },
-    {
-      "Level": 2,
-      "Id": "amcs",
-      "Value": 150
-    },
-    {
-      "Level": 3,
       "Id": "amcs",
       "Value": 150
     },
@@ -94,35 +36,7 @@
       "Value": -100
     },
     {
-      "Level": 2,
-      "Pointer": 1,
-      "Id": "Hfs1",
-      "Type": 2,
-      "Value": -130
-    },
-    {
-      "Level": 3,
-      "Pointer": 1,
-      "Id": "Hfs1",
-      "Type": 2,
-      "Value": -100
-    },
-    {
       "Level": 1,
-      "Pointer": 2,
-      "Id": "Hfs2",
-      "Type": 2,
-      "Value": 1
-    },
-    {
-      "Level": 2,
-      "Pointer": 2,
-      "Id": "Hfs2",
-      "Type": 2,
-      "Value": 1
-    },
-    {
-      "Level": 3,
       "Pointer": 2,
       "Id": "Hfs2",
       "Type": 2,
@@ -136,35 +50,7 @@
       "Value": 0
     },
     {
-      "Level": 2,
-      "Pointer": 3,
-      "Id": "Hfs3",
-      "Type": 2,
-      "Value": 0
-    },
-    {
-      "Level": 3,
-      "Pointer": 3,
-      "Id": "Hfs3",
-      "Type": 2,
-      "Value": 0
-    },
-    {
       "Level": 1,
-      "Pointer": 5,
-      "Id": "Hfs5",
-      "Type": 2,
-      "Value": 1
-    },
-    {
-      "Level": 2,
-      "Pointer": 5,
-      "Id": "Hfs5",
-      "Type": 2,
-      "Value": 1
-    },
-    {
-      "Level": 3,
       "Pointer": 5,
       "Id": "Hfs5",
       "Type": 2,
@@ -178,33 +64,7 @@
       "Value": 99999
     },
     {
-      "Level": 2,
-      "Pointer": 6,
-      "Id": "Hfs6",
-      "Type": 2,
-      "Value": 99999
-    },
-    {
-      "Level": 3,
-      "Pointer": 6,
-      "Id": "Hfs6",
-      "Type": 2,
-      "Value": 99999
-    },
-    {
       "Level": 1,
-      "Id": "adur",
-      "Type": 2,
-      "Value": 0
-    },
-    {
-      "Level": 2,
-      "Id": "adur",
-      "Type": 2,
-      "Value": 0
-    },
-    {
-      "Level": 3,
       "Id": "adur",
       "Type": 2,
       "Value": 0
@@ -216,31 +76,7 @@
       "Value": "X002"
     },
     {
-      "Level": 2,
-      "Id": "aeff",
-      "Type": 3,
-      "Value": "X002"
-    },
-    {
-      "Level": 3,
-      "Id": "aeff",
-      "Type": 3,
-      "Value": "X002"
-    },
-    {
       "Level": 1,
-      "Id": "ahdu",
-      "Type": 2,
-      "Value": 0
-    },
-    {
-      "Level": 2,
-      "Id": "ahdu",
-      "Type": 2,
-      "Value": 0
-    },
-    {
-      "Level": 3,
       "Id": "ahdu",
       "Type": 2,
       "Value": 0
@@ -257,31 +93,7 @@
       "Value": 700
     },
     {
-      "Level": 2,
-      "Id": "aran",
-      "Type": 2,
-      "Value": 700
-    },
-    {
-      "Level": 3,
-      "Id": "aran",
-      "Type": 2,
-      "Value": 700
-    },
-    {
       "Level": 1,
-      "Id": "atar",
-      "Type": 3,
-      "Value": "air,friend,ground,invulnerable,organic,self,vulnerable"
-    },
-    {
-      "Level": 2,
-      "Id": "atar",
-      "Type": 3,
-      "Value": "air,friend,ground,invulnerable,organic,self,vulnerable"
-    },
-    {
-      "Level": 3,
       "Id": "atar",
       "Type": 3,
       "Value": "air,friend,ground,invulnerable,organic,self,vulnerable"
@@ -370,31 +182,7 @@
       "Value": "Rain of Light"
     },
     {
-      "Level": 2,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Rain of Light - [|cffffcc00Level 2|r]"
-    },
-    {
-      "Level": 3,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Rain of Light - [|cffffcc00Level 2|r]"
-    },
-    {
       "Level": 1,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Heal all friendly units in the target area for 100 hit points."
-    },
-    {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Heal all friendly units in the target area for 130 hit points."
-    },
-    {
-      "Level": 3,
       "Id": "aub1",
       "Type": 3,
       "Value": "Heal all friendly units in the target area for 100 hit points."

--- a/mapdata/WarcraftLegacies/AbilityData/A0JQ.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0JQ.json
@@ -147,11 +147,6 @@
       "Value": "Rain of Light"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTN_CR_BLOOD.blp"
-    },
-    {
       "Id": "arpx",
       "Value": 3
     },
@@ -159,16 +154,6 @@
       "Id": "arhk",
       "Type": 3,
       "Value": "E"
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Field of Blood - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Conjures a Field of Blood which Heals allied ground units in a target area over time. |n|n|cffffcc00Level 1|r - Heals 150 hit points over 5 seconds, then 10 hit point every 1 seconds for 35 seconds.|n|cffffcc00Level 2|r - Heals 200 hit points over 5 seconds, then 15 hit point every 1 seconds for 35 seconds.|n|cffffcc00Level 3|r - Heals 250 hit points over 5 seconds, then 20 hit point every 1 seconds for 35 seconds.|n"
     },
     {
       "Id": "asat",

--- a/mapdata/WarcraftLegacies/AbilityData/A0JR.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0JR.json
@@ -6,34 +6,10 @@
   ],
   "Modifications": [
     {
-      "Level": 2,
-      "Id": "aare",
-      "Type": 2,
-      "Value": 900
-    },
-    {
-      "Level": 3,
-      "Id": "aare",
-      "Type": 2,
-      "Value": 900
-    },
-    {
       "Level": 1,
       "Id": "abuf",
       "Type": 3,
       "Value": ""
-    },
-    {
-      "Level": 2,
-      "Id": "abuf",
-      "Type": 3,
-      "Value": "B06L"
-    },
-    {
-      "Level": 3,
-      "Id": "abuf",
-      "Type": 3,
-      "Value": "B06L"
     },
     {
       "Level": 1,
@@ -42,43 +18,9 @@
       "Value": 0
     },
     {
-      "Level": 2,
-      "Id": "acas",
-      "Type": 2,
-      "Value": 1
-    },
-    {
-      "Level": 3,
-      "Id": "acas",
-      "Type": 2,
-      "Value": 1
-    },
-    {
-      "Level": 2,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 120
-    },
-    {
-      "Level": 3,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 120
-    },
-    {
       "Level": 1,
       "Id": "amcs",
       "Value": 150
-    },
-    {
-      "Level": 2,
-      "Id": "amcs",
-      "Value": 200
-    },
-    {
-      "Level": 3,
-      "Id": "amcs",
-      "Value": 250
     },
     {
       "Level": 1,
@@ -88,35 +30,7 @@
       "Value": -150
     },
     {
-      "Level": 2,
-      "Pointer": 1,
-      "Id": "Hfs1",
-      "Type": 2,
-      "Value": -40
-    },
-    {
-      "Level": 3,
-      "Pointer": 1,
-      "Id": "Hfs1",
-      "Type": 2,
-      "Value": -50
-    },
-    {
       "Level": 1,
-      "Pointer": 2,
-      "Id": "Hfs2",
-      "Type": 2,
-      "Value": 1
-    },
-    {
-      "Level": 2,
-      "Pointer": 2,
-      "Id": "Hfs2",
-      "Type": 2,
-      "Value": 1
-    },
-    {
-      "Level": 3,
       "Pointer": 2,
       "Id": "Hfs2",
       "Type": 2,
@@ -130,35 +44,7 @@
       "Value": 0
     },
     {
-      "Level": 2,
-      "Pointer": 3,
-      "Id": "Hfs3",
-      "Type": 2,
-      "Value": -15
-    },
-    {
-      "Level": 3,
-      "Pointer": 3,
-      "Id": "Hfs3",
-      "Type": 2,
-      "Value": -20
-    },
-    {
       "Level": 1,
-      "Pointer": 5,
-      "Id": "Hfs5",
-      "Type": 2,
-      "Value": 1
-    },
-    {
-      "Level": 2,
-      "Pointer": 5,
-      "Id": "Hfs5",
-      "Type": 2,
-      "Value": 1
-    },
-    {
-      "Level": 3,
       "Pointer": 5,
       "Id": "Hfs5",
       "Type": 2,
@@ -172,36 +58,10 @@
       "Value": 99999
     },
     {
-      "Level": 2,
-      "Pointer": 6,
-      "Id": "Hfs6",
-      "Type": 2,
-      "Value": 900
-    },
-    {
-      "Level": 3,
-      "Pointer": 6,
-      "Id": "Hfs6",
-      "Type": 2,
-      "Value": 900
-    },
-    {
       "Level": 1,
       "Id": "adur",
       "Type": 2,
       "Value": 0
-    },
-    {
-      "Level": 2,
-      "Id": "adur",
-      "Type": 2,
-      "Value": 35
-    },
-    {
-      "Level": 3,
-      "Id": "adur",
-      "Type": 2,
-      "Value": 35
     },
     {
       "Level": 1,
@@ -210,34 +70,10 @@
       "Value": "X00K"
     },
     {
-      "Level": 2,
-      "Id": "aeff",
-      "Type": 3,
-      "Value": "X00F"
-    },
-    {
-      "Level": 3,
-      "Id": "aeff",
-      "Type": 3,
-      "Value": "X00F"
-    },
-    {
       "Level": 1,
       "Id": "ahdu",
       "Type": 2,
       "Value": 0
-    },
-    {
-      "Level": 2,
-      "Id": "ahdu",
-      "Type": 2,
-      "Value": 5
-    },
-    {
-      "Level": 3,
-      "Id": "ahdu",
-      "Type": 2,
-      "Value": 5
     },
     {
       "Id": "arac",
@@ -245,34 +81,10 @@
       "Value": "orc"
     },
     {
-      "Level": 2,
-      "Id": "aran",
-      "Type": 2,
-      "Value": 650
-    },
-    {
-      "Level": 3,
-      "Id": "aran",
-      "Type": 2,
-      "Value": 650
-    },
-    {
       "Level": 1,
       "Id": "atar",
       "Type": 3,
       "Value": "air,friend,ground,invulnerable,organic,self,vulnerable"
-    },
-    {
-      "Level": 2,
-      "Id": "atar",
-      "Type": 3,
-      "Value": "friend,ground,neutral,self"
-    },
-    {
-      "Level": 3,
-      "Id": "atar",
-      "Type": 3,
-      "Value": "friend,ground,neutral,self"
     },
     {
       "Id": "alev",
@@ -348,34 +160,10 @@
       "Value": "Dark Energy"
     },
     {
-      "Level": 2,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Field of Blood - [|cffffcc00Level 2|r]"
-    },
-    {
-      "Level": 3,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Field of Blood - [|cffffcc00Level 3|r]"
-    },
-    {
       "Level": 1,
       "Id": "aub1",
       "Type": 3,
       "Value": "Heal all friendly units in the area for 150 hit points."
-    },
-    {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Conjures a Field of Blood which Heals allied ground units in a target area over time. |n|nHeals 200 hit points over 5 seconds, then 15 hit point every 1 seconds for 35 seconds.|n"
-    },
-    {
-      "Level": 3,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Conjures a Field of Blood which Heals allied ground units in a target area over time. |n|cffffcc00|n|rHeals 250 hit points over 5 seconds, then 20 hit point every 1 seconds for 35 seconds."
     },
     {
       "Id": "aeat",

--- a/mapdata/WarcraftLegacies/AbilityData/A0JR.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0JR.json
@@ -125,11 +125,6 @@
       "Value": "Dark Energy"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTN_CR_BLOOD.blp"
-    },
-    {
       "Id": "arpx",
       "Value": 3
     },
@@ -137,16 +132,6 @@
       "Id": "arhk",
       "Type": 3,
       "Value": "E"
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Field of Blood - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Conjures a Field of Blood which Heals allied ground units in a target area over time. |n|n|cffffcc00Level 1|r - Heals 150 hit points over 5 seconds, then 10 hit point every 1 seconds for 35 seconds.|n|cffffcc00Level 2|r - Heals 200 hit points over 5 seconds, then 15 hit point every 1 seconds for 35 seconds.|n|cffffcc00Level 3|r - Heals 250 hit points over 5 seconds, then 20 hit point every 1 seconds for 35 seconds.|n"
     },
     {
       "Id": "asat",

--- a/mapdata/WarcraftLegacies/AbilityData/A0JV.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0JV.json
@@ -86,11 +86,6 @@
       "Value": "W"
     },
     {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Summons \u003CAOsf,DataB1\u003E Spirit Wolves to fight the Far Seer\u0027s enemies. |nLasts \u003CAOsf,Dur1\u003E seconds. |n|n|cffffcc00Level 1|r - \u003Cosw1,realHP\u003E hit points, \u003Cosw1,mindmg1\u003E - \u003Cosw1,maxdmg1\u003E damage. 2 wolves summoned.|n|cffffcc00Level 2|r - \u003Cosw2,realHP\u003E hit points, \u003Cosw2,mindmg1\u003E - \u003Cosw2,maxdmg1\u003E damage and Critical Strike. 2 wolves summoned.|n|cffffcc00Level 3|r - \u003Cosw3,realHP\u003E hit points, \u003Cosw3,mindmg1\u003E - \u003Cosw3,maxdmg1\u003E damage and Critical Strike. 2 wolves summoned.|n|cffffcc00Level 4|r - \u003Cosw3,realHP\u003E hit points, \u003Cosw3,mindmg1\u003E - \u003Cosw3,maxdmg1\u003E damage, and Critical Strike. 4 wolves summoned.|n|cffffcc00Level 5|r - \u003Cosw3,realHP\u003E hit points, \u003Cosw3,mindmg1\u003E - \u003Cosw3,maxdmg1\u003E damage and Critical Strike. 6 wolves summoned.|n"
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A0KC.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0KC.json
@@ -13,35 +13,7 @@
       "Value": 60
     },
     {
-      "Level": 2,
-      "Pointer": 2,
-      "Id": "Nic2",
-      "Type": 2,
-      "Value": 60
-    },
-    {
-      "Level": 3,
-      "Pointer": 2,
-      "Id": "Nic2",
-      "Type": 2,
-      "Value": 80
-    },
-    {
       "Level": 1,
-      "Pointer": 3,
-      "Id": "Nic3",
-      "Type": 2,
-      "Value": 160
-    },
-    {
-      "Level": 2,
-      "Pointer": 3,
-      "Id": "Nic3",
-      "Type": 2,
-      "Value": 160
-    },
-    {
-      "Level": 3,
       "Pointer": 3,
       "Id": "Nic3",
       "Type": 2,
@@ -55,36 +27,10 @@
       "Value": 45
     },
     {
-      "Level": 2,
-      "Pointer": 4,
-      "Id": "Nic4",
-      "Type": 2,
-      "Value": 45
-    },
-    {
-      "Level": 3,
-      "Pointer": 4,
-      "Id": "Nic4",
-      "Type": 2,
-      "Value": 65
-    },
-    {
       "Level": 1,
       "Id": "adur",
       "Type": 2,
       "Value": 10
-    },
-    {
-      "Level": 2,
-      "Id": "adur",
-      "Type": 2,
-      "Value": 10
-    },
-    {
-      "Level": 3,
-      "Id": "adur",
-      "Type": 2,
-      "Value": 15
     },
     {
       "Id": "aher",
@@ -95,18 +41,6 @@
       "Id": "ahdu",
       "Type": 2,
       "Value": 10
-    },
-    {
-      "Level": 2,
-      "Id": "ahdu",
-      "Type": 2,
-      "Value": 10
-    },
-    {
-      "Level": 3,
-      "Id": "ahdu",
-      "Type": 2,
-      "Value": 15
     },
     {
       "Id": "amho",
@@ -147,18 +81,6 @@
       "Id": "amat",
       "Type": 3,
       "Value": ""
-    },
-    {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Each attack made is enhanced with living flames that cling to the target. These flames add \u003CA0KC,DataA2\u003E damage on the first attack, twice as much on the second attack, three times as much on the third attack, etc.|n|nIf a unit dies while under this effect, it is incinerated, causing up to \u003CA0KC,DataB2\u003E damage to all nearby hostile units."
-    },
-    {
-      "Level": 3,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Each attack made is enhanced with living flames that cling to the target. These flames add \u003CA0KC,DataA3\u003E damage on the first attack, twice as much on the second attack, three times as much on the third attack, etc.|n|nIf a unit dies while under this effect, it is incinerated, causing up to \u003CA0KC,DataB3\u003E damage to all nearby hostile units."
     },
     {
       "Level": 1,

--- a/mapdata/WarcraftLegacies/AbilityData/A0KY.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0KY.json
@@ -21,12 +21,6 @@
       "Value": "The Generator will need one of the following power sources to power the Dimensional Ship:|n-The Eye of Sargeras|n-The Book of Medivh|n-A Vial of the Sunwell|n-The Crown of the Triumvirate|n-Sulfuras, Hand of Ragnaros|n-The Helm of Domination"
     },
     {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Increases the rate at which this unit gathers lumber."
-    },
-    {
       "Id": "aart",
       "Type": 3,
       "Value": "ReplaceableTextures\\PassiveButtons\\PASArcaneEnergy.blp"

--- a/mapdata/WarcraftLegacies/AbilityData/A0LR.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0LR.json
@@ -114,11 +114,6 @@
       "Value": "Ascend"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTNReplicate.blp"
-    },
-    {
       "Id": "arpx",
       "Value": 2
     },
@@ -126,16 +121,6 @@
       "Id": "arhk",
       "Type": 3,
       "Value": "R"
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Mass Simulacrum - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Creates a summoned copy of all friendly units in the target area. Lasts 30 seconds.|n|n|cffffcc00Level 1|r - Each summoned unit has 30% reduced hit points and attack damage. |n|cffffcc00Level 2|r - Each summoned unit has 10% reduced hit points and attack damage. |n|cffffcc00Level 3|r - Each summoned unit has 10% increased hit points and attack damage.  |n|cffffcc00Level 4|r - Each summoned unit has 30% increased hit points and attack damage."
     },
     {
       "Id": "atat",

--- a/mapdata/WarcraftLegacies/AbilityData/A0LR.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0LR.json
@@ -6,61 +6,10 @@
   ],
   "Modifications": [
     {
-      "Level": 2,
-      "Id": "aare",
-      "Type": 2,
-      "Value": 150
-    },
-    {
-      "Level": 3,
-      "Id": "aare",
-      "Type": 2,
-      "Value": 150
-    },
-    {
-      "Level": 4,
-      "Id": "aare",
-      "Type": 2,
-      "Value": 150
-    },
-    {
       "Level": 1,
       "Id": "acdn",
       "Type": 2,
       "Value": 5
-    },
-    {
-      "Level": 2,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 50
-    },
-    {
-      "Level": 3,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 50
-    },
-    {
-      "Level": 4,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 50
-    },
-    {
-      "Level": 2,
-      "Id": "amcs",
-      "Value": 190
-    },
-    {
-      "Level": 3,
-      "Id": "amcs",
-      "Value": 205
-    },
-    {
-      "Level": 4,
-      "Id": "amcs",
-      "Value": 220
     },
     {
       "Level": 1,
@@ -70,49 +19,10 @@
       "Value": 0.001
     },
     {
-      "Level": 2,
-      "Pointer": 1,
-      "Id": "Ncl1",
-      "Type": 2,
-      "Value": 1.5
-    },
-    {
-      "Level": 3,
-      "Pointer": 1,
-      "Id": "Ncl1",
-      "Type": 2,
-      "Value": 1.5
-    },
-    {
-      "Level": 4,
-      "Pointer": 1,
-      "Id": "Ncl1",
-      "Type": 2,
-      "Value": 1.5
-    },
-    {
       "Level": 1,
       "Pointer": 2,
       "Id": "Ncl2",
       "Value": 1
-    },
-    {
-      "Level": 2,
-      "Pointer": 2,
-      "Id": "Ncl2",
-      "Value": 2
-    },
-    {
-      "Level": 3,
-      "Pointer": 2,
-      "Id": "Ncl2",
-      "Value": 2
-    },
-    {
-      "Level": 4,
-      "Pointer": 2,
-      "Id": "Ncl2",
-      "Value": 2
     },
     {
       "Level": 1,
@@ -121,70 +31,13 @@
       "Value": 9
     },
     {
-      "Level": 2,
-      "Pointer": 3,
-      "Id": "Ncl3",
-      "Value": 3
-    },
-    {
-      "Level": 3,
-      "Pointer": 3,
-      "Id": "Ncl3",
-      "Value": 3
-    },
-    {
-      "Level": 4,
-      "Pointer": 3,
-      "Id": "Ncl3",
-      "Value": 3
-    },
-    {
       "Level": 1,
       "Pointer": 5,
       "Id": "Ncl5",
       "Value": 0
     },
     {
-      "Level": 2,
-      "Pointer": 5,
-      "Id": "Ncl5",
-      "Value": 0
-    },
-    {
-      "Level": 3,
-      "Pointer": 5,
-      "Id": "Ncl5",
-      "Value": 0
-    },
-    {
-      "Level": 4,
-      "Pointer": 5,
-      "Id": "Ncl5",
-      "Value": 0
-    },
-    {
       "Level": 1,
-      "Pointer": 6,
-      "Id": "Ncl6",
-      "Type": 3,
-      "Value": "farsight"
-    },
-    {
-      "Level": 2,
-      "Pointer": 6,
-      "Id": "Ncl6",
-      "Type": 3,
-      "Value": "farsight"
-    },
-    {
-      "Level": 3,
-      "Pointer": 6,
-      "Id": "Ncl6",
-      "Type": 3,
-      "Value": "farsight"
-    },
-    {
-      "Level": 4,
       "Pointer": 6,
       "Id": "Ncl6",
       "Type": 3,
@@ -204,24 +57,6 @@
       "Id": "aran",
       "Type": 2,
       "Value": 300
-    },
-    {
-      "Level": 2,
-      "Id": "aran",
-      "Type": 2,
-      "Value": 700
-    },
-    {
-      "Level": 3,
-      "Id": "aran",
-      "Type": 2,
-      "Value": 700
-    },
-    {
-      "Level": 4,
-      "Id": "aran",
-      "Type": 2,
-      "Value": 700
     },
     {
       "Id": "aher",
@@ -314,46 +149,10 @@
       "Value": "Ascend"
     },
     {
-      "Level": 2,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Mass Simulacrum - [|cffffcc00Level 2|r]"
-    },
-    {
-      "Level": 3,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Mass Simulacrum - [|cffffcc00Level 3|r]"
-    },
-    {
-      "Level": 4,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Mass Simulacrum - [|cffffcc00Level 4|r]"
-    },
-    {
       "Level": 1,
       "Id": "aub1",
       "Type": 3,
       "Value": "Cast this spell on the Frozen Throne to have him ascend to become the indomitable Lich King."
-    },
-    {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Creates a summoned copy of all friendly units in the target area. Each summoned unit has 10% reduced hit points and attack damage. Lasts 30 seconds."
-    },
-    {
-      "Level": 3,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Creates a summoned copy of all friendly units in the target area. Each summoned unit has 10% increased hit points and attack damage. Lasts 30 seconds."
-    },
-    {
-      "Level": 4,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Creates a summoned copy of all friendly units in the target area. Each summoned unit has 30% increased hit points and attack damage. Lasts 30 seconds."
     },
     {
       "Id": "abpx",

--- a/mapdata/WarcraftLegacies/AbilityData/A0LW.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0LW.json
@@ -52,11 +52,6 @@
       "Value": "D"
     },
     {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Short distance teleportation that allows the Warden to move in and out of combat. |n|n|cffffcc00Level 1|r - \u003CAEbl,Cool1\u003E second cooldown, \u003CAEbl,Cost1\u003E mana. |n|cffffcc00Level 2|r - \u003CAEbl,Cool2\u003E second cooldown, \u003CAEbl,Cost2\u003E mana. |n|cffffcc00Level 3|r - \u003CAEbl,Cool3\u003E second cooldown, \u003CAEbl,Cost3\u003E mana. |n|cffffcc00Level 4|r - \u003CAEbl,Cool4\u003E second cooldown, \u003CAEbl,Cost4\u003E mana."
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A0M1.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0M1.json
@@ -66,11 +66,6 @@
       "Value": "Q"
     },
     {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Summons immobile serpentine wards to attack the caster\u0027s enemies. The wards are immune to magic. |nLasts \u003CArsw,Dur1\u003E seconds. |n|n|cffffcc00Attacks land and air units.|r |n|n|cffffcc00Level 1|r - \u003CArsw,DataA1\u003E wards, \u003Cosp1,realHP\u003E hit points, \u003Cosp1,mindmg1\u003E - \u003Cosp1,maxdmg1\u003E damage. |n|cffffcc00Level 2|r - \u003CArsw,DataA2\u003E wards, \u003Cosp2,realHP\u003E hit points, \u003Cosp2,mindmg1\u003E - \u003Cosp2,maxdmg1\u003E damage. |n|cffffcc00Level 3|r - \u003CArsw,DataA3\u003E wards, \u003Cosp3,realHP\u003E hit points, \u003Cosp3,mindmg1\u003E - \u003Cosp3,maxdmg1\u003E damage. |n|cffffcc00Level 4|r - \u003CArsw,DataA4\u003E wards, \u003Cosp4,realHP\u003E hit points, \u003Cosp4,mindmg1\u003E - \u003Cosp4,maxdmg1\u003E damage."
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A0M1.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0M1.json
@@ -11,39 +11,6 @@
       "Value": 75
     },
     {
-      "Level": 2,
-      "Id": "amcs",
-      "Value": 90
-    },
-    {
-      "Level": 3,
-      "Id": "amcs",
-      "Value": 105
-    },
-    {
-      "Level": 4,
-      "Id": "amcs",
-      "Value": 120
-    },
-    {
-      "Level": 2,
-      "Pointer": 1,
-      "Id": "Hwe2",
-      "Value": 4
-    },
-    {
-      "Level": 3,
-      "Pointer": 1,
-      "Id": "Hwe2",
-      "Value": 4
-    },
-    {
-      "Level": 4,
-      "Pointer": 1,
-      "Id": "Hwe2",
-      "Value": 4
-    },
-    {
       "Level": 1,
       "Id": "Hwe1",
       "Type": 3,
@@ -110,46 +77,10 @@
       "Value": "Tidal Serpent"
     },
     {
-      "Level": 2,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Serpent Ward (|cffffcc00Q|r) - [|cffffcc00Level 2|r]"
-    },
-    {
-      "Level": 3,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Serpent Ward (|cffffcc00Q|r) - [|cffffcc00Level 3|r]"
-    },
-    {
-      "Level": 4,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Serpent Ward (|cffffcc00Q|r) - [|cffffcc00Level 4|r]"
-    },
-    {
       "Level": 1,
       "Id": "aub1",
       "Type": 3,
       "Value": "Summons 1 immobile deep sea serpent to attack enemies. The ward has 2400 hit points and deals 92 - 93 damage. |nLasts 30 seconds. |n|n|cffffcc00Attacks land and air units.|r"
-    },
-    {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Summons \u003CArsw,DataA2\u003E immobile serpentine wards to attack enemies. The ward has \u003Cosp2,realHP\u003E hit points, is magic immune, and deals \u003Cosp2,mindmg1\u003E - \u003Cosp2,maxdmg1\u003E damage. |nLasts \u003CArsw,Dur2\u003E seconds. |n|n|cffffcc00Attacks land and air units.|r"
-    },
-    {
-      "Level": 3,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Summons \u003CArsw,DataA3\u003E immobile serpentine wards to attack enemies. The ward has \u003Cosp3,realHP\u003E hit points, is magic immune, and deals \u003Cosp3,mindmg1\u003E - \u003Cosp3,maxdmg1\u003E damage. |nLasts \u003CArsw,Dur3\u003E seconds. |n|n|cffffcc00Attacks land and air units.|r"
-    },
-    {
-      "Level": 4,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Summons \u003CArsw,DataA4\u003E immobile serpentine wards to attack enemies. The ward has \u003Cosp4,realHP\u003E hit points, is magic immune, and deals \u003Cosp4,mindmg1\u003E - \u003Cosp4,maxdmg1\u003E damage. |nLasts \u003CArsw,Dur4\u003E seconds. |n|n|cffffcc00Attacks land and air units.|r"
     },
     {
       "Id": "anam",

--- a/mapdata/WarcraftLegacies/AbilityData/A0MN.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0MN.json
@@ -21,12 +21,6 @@
       "Value": "This unit\u0027s abilities consume Oil instead of mana."
     },
     {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Increases the rate at which this unit gathers lumber."
-    },
-    {
       "Id": "aart",
       "Type": 3,
       "Value": "ReplaceableTextures\\PassiveButtons\\PASOil.blp"

--- a/mapdata/WarcraftLegacies/AbilityData/A0MQ.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0MQ.json
@@ -6,46 +6,11 @@
   ],
   "Modifications": [
     {
-      "Level": 3,
-      "Pointer": 1,
-      "Id": "War1",
-      "Type": 2,
-      "Value": 25
-    },
-    {
       "Level": 1,
       "Pointer": 2,
       "Id": "War2",
       "Type": 2,
       "Value": 75
-    },
-    {
-      "Level": 2,
-      "Pointer": 2,
-      "Id": "War2",
-      "Type": 2,
-      "Value": 75
-    },
-    {
-      "Level": 3,
-      "Pointer": 2,
-      "Id": "War2",
-      "Type": 2,
-      "Value": 100
-    },
-    {
-      "Level": 3,
-      "Pointer": 3,
-      "Id": "War3",
-      "Type": 2,
-      "Value": 250
-    },
-    {
-      "Level": 3,
-      "Pointer": 4,
-      "Id": "War4",
-      "Type": 2,
-      "Value": 350
     },
     {
       "Id": "alev",
@@ -55,12 +20,6 @@
       "Id": "arac",
       "Type": 3,
       "Value": "human"
-    },
-    {
-      "Level": 3,
-      "Id": "atar",
-      "Type": 3,
-      "Value": "ground,enemy,neutral"
     },
     {
       "Id": "abpx",
@@ -74,30 +33,6 @@
       "Id": "ansf",
       "Type": 3,
       "Value": "(Alexandros)"
-    },
-    {
-      "Level": 2,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Pulverize - [|cffffcc00Level 2|r]"
-    },
-    {
-      "Level": 3,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Pulverize - [|cffffcc00Level 3|r]"
-    },
-    {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Gives a \u003CA0MQ,DataA2\u003E% chance that an attack will deal \u003CA0MQ,DataB2\u003E damage to nearby units."
-    },
-    {
-      "Level": 3,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Gives a \u003CA0MQ,DataA3\u003E% chance that an attack will deal \u003CA0MQ,DataB3\u003E damage to nearby units."
     },
     {
       "Level": 1,

--- a/mapdata/WarcraftLegacies/AbilityData/A0N2.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0N2.json
@@ -75,24 +75,9 @@
       "Value": "Grasping Vines"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTNDisenchant.blp"
-    },
-    {
       "Id": "arhk",
       "Type": 3,
       "Value": "E"
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Blazing Aura - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Undead and Demons are weakened in the face of the Light. Decreases hitpoint regeneration and movement speed of nearby enemy units. |n|n|cffffcc00Level 1|r - 50% degeneration, 3% movement speed reduction.|n|cffffcc00Level 2|r - 100% degeneration, 6% movement speed reduction.|n|cffffcc00Level 3|r - 200% degeneration, 9% movement speed reduction."
     },
     {
       "Id": "atat",

--- a/mapdata/WarcraftLegacies/AbilityData/A0N4.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0N4.json
@@ -58,11 +58,6 @@
       "Value": "W"
     },
     {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Reveals the area of the map that it is cast upon. Also reveals invisible units. |n|n|cffffcc00Level 1|r - Reveals a small area for \u003CAOfs,Cost1\u003E mana. |n|cffffcc00Level 2|r - Reveals a large area for \u003CAOfs,Cost2\u003E mana. |n|cffffcc00Level 3|r - Reveals a very large area for \u003CAOfs,Cost3\u003E mana.|n|cffffcc00Level 4|r - Reveals a huge area for \u003CAOfs,Cost4\u003E mana.|n|cffffcc00Level 5|r - Reveals a massive area for \u003CAOfs,Cost5\u003E mana."
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A0N8.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0N8.json
@@ -77,12 +77,6 @@
       "Value": 300
     },
     {
-      "Level": 4,
-      "Id": "Ntou",
-      "Type": 3,
-      "Value": "n0D0"
-    },
-    {
       "Level": 1,
       "Id": "aran",
       "Type": 2,
@@ -101,35 +95,6 @@
       "Value": 150
     },
     {
-      "Level": 4,
-      "Id": "aran",
-      "Type": 2,
-      "Value": 600
-    },
-    {
-      "Level": 4,
-      "Id": "ahdu",
-      "Type": 2,
-      "Value": 180
-    },
-    {
-      "Level": 4,
-      "Id": "adur",
-      "Type": 2,
-      "Value": 180
-    },
-    {
-      "Level": 4,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 90
-    },
-    {
-      "Level": 4,
-      "Id": "amcs",
-      "Value": 300
-    },
-    {
       "Level": 1,
       "Id": "acas",
       "Type": 2,
@@ -143,12 +108,6 @@
     },
     {
       "Level": 3,
-      "Id": "acas",
-      "Type": 2,
-      "Value": 2
-    },
-    {
-      "Level": 4,
       "Id": "acas",
       "Type": 2,
       "Value": 2
@@ -238,18 +197,6 @@
       "Id": "atp1",
       "Type": 3,
       "Value": "Citadel Shield - [|cffffcc00Level 1|r]"
-    },
-    {
-      "Level": 4,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Citadel Shield - [|cffffcc00Level 4|r]"
-    },
-    {
-      "Level": 4,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Channel the Citadel Shield for up to 180 seconds. It will deal 12 damage per second in a 1000 area of effect. It will also buff friendly buildings in the area giving them 10 additional armor. Has a 180 seconds cooldown and 2 seconds casting time."
     },
     {
       "Id": "aani",

--- a/mapdata/WarcraftLegacies/AbilityData/A0O2.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0O2.json
@@ -21,12 +21,6 @@
       "Value": "This unit has 2 goblin crewing it, they will jump out when the tank is destroyed."
     },
     {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Increases the rate at which this unit gathers lumber."
-    },
-    {
       "Id": "aart",
       "Type": 3,
       "Value": "ReplaceableTextures\\PassiveButtons\\PASGoblinCommando.blp"

--- a/mapdata/WarcraftLegacies/AbilityData/A0OE.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0OE.json
@@ -197,16 +197,6 @@
       "Value": "Q"
     },
     {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Greater Storm Bolt (|cffffcc00Q|r) - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "A magical hammer that is thrown at an enemy unit, causing damage and stunning the target. |n|n|cffffcc00Level 1|r - 250 damage, 4 second stun. 2 second on Heroes.|n|cffffcc00Level 2|r - 300 damage, 5 second stun. 2.5 seconds on Heroes.|n|cffffcc00Level 3|r - 350 damage, 6 second stun. 3 seconds on Heroes.|n|cffffcc00Level 4|r - 400 damage, 7 second stun. 3.5 seconds on Heroes"
-    },
-    {
       "Level": 2,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A0P9.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0P9.json
@@ -101,11 +101,6 @@
       "Value": "Portal to Azuremyst"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTNWarpPortal.blp"
-    },
-    {
       "Id": "arpx",
       "Value": 3
     },
@@ -113,16 +108,6 @@
       "Id": "arhk",
       "Type": 3,
       "Value": "R"
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Slipstream - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Opens a two-way portal to the target location. The portal becomes usable after 5 seconds, and closes 10 seconds after the caster stops channeling.|n|n|cffffcc00Level 1|r - \u003CA00D,Rng1\u003E range. |n|cffffcc00Level 2|r - \u003CA00D,Rng2\u003E range. |n|cffffcc00Level 3|r - \u003CA00D,Rng3\u003E range."
     },
     {
       "Id": "atat",

--- a/mapdata/WarcraftLegacies/AbilityData/A0P9.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0P9.json
@@ -12,43 +12,7 @@
       "Value": 45
     },
     {
-      "Level": 2,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 45
-    },
-    {
-      "Level": 3,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 45
-    },
-    {
-      "Level": 2,
-      "Id": "amcs",
-      "Value": 250
-    },
-    {
-      "Level": 3,
-      "Id": "amcs",
-      "Value": 350
-    },
-    {
       "Level": 1,
-      "Pointer": 1,
-      "Id": "Ncl1",
-      "Type": 2,
-      "Value": 300
-    },
-    {
-      "Level": 2,
-      "Pointer": 1,
-      "Id": "Ncl1",
-      "Type": 2,
-      "Value": 300
-    },
-    {
-      "Level": 3,
       "Pointer": 1,
       "Id": "Ncl1",
       "Type": 2,
@@ -61,51 +25,13 @@
       "Value": 17
     },
     {
-      "Level": 2,
-      "Pointer": 3,
-      "Id": "Ncl3",
-      "Value": 17
-    },
-    {
-      "Level": 3,
-      "Pointer": 3,
-      "Id": "Ncl3",
-      "Value": 17
-    },
-    {
       "Level": 1,
       "Pointer": 5,
       "Id": "Ncl5",
       "Value": 0
     },
     {
-      "Level": 2,
-      "Pointer": 5,
-      "Id": "Ncl5",
-      "Value": 0
-    },
-    {
-      "Level": 3,
-      "Pointer": 5,
-      "Id": "Ncl5",
-      "Value": 0
-    },
-    {
       "Level": 1,
-      "Pointer": 6,
-      "Id": "Ncl6",
-      "Type": 3,
-      "Value": "corrosivebreath"
-    },
-    {
-      "Level": 2,
-      "Pointer": 6,
-      "Id": "Ncl6",
-      "Type": 3,
-      "Value": "corrosivebreath"
-    },
-    {
-      "Level": 3,
       "Pointer": 6,
       "Id": "Ncl6",
       "Type": 3,
@@ -115,30 +41,6 @@
       "Id": "arac",
       "Type": 3,
       "Value": "orc"
-    },
-    {
-      "Level": 2,
-      "Id": "aran",
-      "Type": 2,
-      "Value": 6000
-    },
-    {
-      "Level": 3,
-      "Id": "aran",
-      "Type": 2,
-      "Value": 9000
-    },
-    {
-      "Level": 2,
-      "Pointer": 2,
-      "Id": "Ncl2",
-      "Value": 2
-    },
-    {
-      "Level": 3,
-      "Pointer": 2,
-      "Id": "Ncl2",
-      "Value": 2
     },
     {
       "Id": "aher",
@@ -234,34 +136,10 @@
       "Value": "Portal to Azuremyst"
     },
     {
-      "Level": 2,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Slipstream - [|cffffcc00Level 2|r]"
-    },
-    {
-      "Level": 3,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Slipstream - [|cffffcc00Level 3|r]"
-    },
-    {
       "Level": 1,
       "Id": "aub1",
       "Type": 3,
       "Value": "Opens a two-way portal to Azuremyst. The portal becomes usable after 20 seconds, and closes 10 seconds after the caster stops channeling."
-    },
-    {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Opens a two-way portal to the target location within a range of \u003CA00D,Rng2\u003E. The portal becomes usable after 5 seconds, and closes 20 seconds after the caster stops channeling."
-    },
-    {
-      "Level": 3,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Opens a two-way portal to the target location within a range of \u003CA00D,Rng3\u003E. The portal becomes usable after 5 seconds, and closes 30 seconds after the caster stops channeling."
     },
     {
       "Id": "abpy",

--- a/mapdata/WarcraftLegacies/AbilityData/A0PL.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0PL.json
@@ -55,21 +55,6 @@
       "Value": "Blessing of Seradane"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": ""
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": ""
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Increases movement speed by 5% and attack speed by 3% for nearby friendly units"
-    },
-    {
       "Id": "atat",
       "Type": 3,
       "Value": ""

--- a/mapdata/WarcraftLegacies/AbilityData/A0Q1.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0Q1.json
@@ -59,11 +59,6 @@
       "Value": "E"
     },
     {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Each attack made is enhanced with living flames that cling to the target. These flames add a small amount of damage on the first attack, twice as much on the second attack, three times as much on the third attack, etc.|n|nIf a unit dies while under this effect, it is incinerated, causing significant damage to all nearby hostile units.|n|n|cffffcc00Level 1|r - 0.5 bonus damage multiplier, 30 incineration damage.|n|cffffcc00Level 2|r - 1 bonus damage multiplier, 40 incineration damage.|n|cffffcc00Level 3|r - 1.5 bonus damage multiplier, 50 incineration damage.|n|cffffcc00Level 4|r - 2 bonus damage multiplier, 60 incineration damage."
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A0Q3.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0Q3.json
@@ -94,11 +94,6 @@
       "Value": "Q"
     },
     {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Hurls a bolt of damaging lightning at a target enemy that jumps to nearby enemies. Each jump deals less damage. |n|n|cffffcc00Level 1|r - \u003CAOcl,DataA1\u003E damage, jumps \u003CAOcl,DataB1\u003E times. |n|cffffcc00Level 2|r - \u003CAOcl,DataA2\u003E damage, jumps \u003CAOcl,DataB2\u003E times. |n|cffffcc00Level 3|r - \u003CAOcl,DataA3\u003E damage, jumps \u003CAOcl,DataB3\u003E times.|n|cffffcc00Level 4|r - \u003CAOcl,DataA4\u003E damage, jumps \u003CAOcl,DataB4\u003E times."
-    },
-    {
       "Id": "asat",
       "Type": 3,
       "Value": "Abilities\\Spells\\Other\\Incinerate\\FireLordDeathExplode.mdl"

--- a/mapdata/WarcraftLegacies/AbilityData/A0Q7.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0Q7.json
@@ -82,16 +82,6 @@
       "Value": "W"
     },
     {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Flame Strike (|cffffcc00Q|r) - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Conjures a pillar of fire which damages ground units in a target area over time. |n|n|cffffcc00Level 1|r - 270 damage over 3 seconds, followed by minor damage for 6 seconds. |n|cffffcc00Level 2|r - 315 damage over 3 seconds, followed by light damage for 6 seconds. |n|cffffcc00Level 3|r - 360 damage over 3 seconds, followed by moderate damage for 6 seconds. |n|cffffcc00Level 4|r - 405 damage over 3 seconds, followed by major damage for 6 seconds."
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A0QH.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0QH.json
@@ -12,24 +12,6 @@
       "Value": "B01A"
     },
     {
-      "Level": 2,
-      "Id": "abuf",
-      "Type": 3,
-      "Value": "B01A"
-    },
-    {
-      "Level": 3,
-      "Id": "abuf",
-      "Type": 3,
-      "Value": "B01A"
-    },
-    {
-      "Level": 4,
-      "Id": "abuf",
-      "Type": 3,
-      "Value": "B01A"
-    },
-    {
       "Level": 1,
       "Pointer": 1,
       "Id": "Oae1",
@@ -37,35 +19,7 @@
       "Value": 0.05
     },
     {
-      "Level": 3,
-      "Pointer": 1,
-      "Id": "Oae1",
-      "Type": 2,
-      "Value": 0.15
-    },
-    {
       "Level": 1,
-      "Pointer": 2,
-      "Id": "Oae2",
-      "Type": 2,
-      "Value": 0
-    },
-    {
-      "Level": 2,
-      "Pointer": 2,
-      "Id": "Oae2",
-      "Type": 2,
-      "Value": 0
-    },
-    {
-      "Level": 3,
-      "Pointer": 2,
-      "Id": "Oae2",
-      "Type": 2,
-      "Value": 0
-    },
-    {
-      "Level": 4,
       "Pointer": 2,
       "Id": "Oae2",
       "Type": 2,
@@ -79,20 +33,6 @@
       "Id": "arac",
       "Type": 3,
       "Value": "human"
-    },
-    {
-      "Level": 2,
-      "Pointer": 1,
-      "Id": "Oae1",
-      "Type": 2,
-      "Value": 0.1
-    },
-    {
-      "Level": 4,
-      "Pointer": 1,
-      "Id": "Oae1",
-      "Type": 2,
-      "Value": 0.2
     },
     {
       "Id": "aher",
@@ -140,46 +80,10 @@
       "Value": "Conveyance Aura"
     },
     {
-      "Level": 2,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Conveyance Aura - [|cffffcc00Level 2|r]"
-    },
-    {
-      "Level": 3,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Conveyance Aura - [|cffffcc00Level 3|r]"
-    },
-    {
-      "Level": 4,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Conveyance Aura - [|cffffcc00Level 4|r]"
-    },
-    {
       "Level": 1,
       "Id": "aub1",
       "Type": 3,
       "Value": "Increases nearby friendly units\u0027 movement speed by 5%."
-    },
-    {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Increases nearby friendly units\u0027 movement speed by 10%."
-    },
-    {
-      "Level": 3,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Increases nearby friendly units\u0027 movement speed by 15%."
-    },
-    {
-      "Level": 4,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Increases nearby friendly units\u0027 movement speed by 20%."
     },
     {
       "Id": "auar",

--- a/mapdata/WarcraftLegacies/AbilityData/A0QH.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0QH.json
@@ -54,21 +54,6 @@
       "Value": "Conveyance Aura"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTNLeadershipAura.blp"
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Conveyance Aura - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "The unit is an adept commander and his skills give his armies increased mobility. Increases the movement speed of all nearby friendly units.|n|n|cffffcc00Level 1|r - 5% increased movement speed."
-    },
-    {
       "Id": "atat",
       "Type": 3,
       "Value": "war3mapImported\\SpiralAura.mdx"

--- a/mapdata/WarcraftLegacies/AbilityData/A0QI.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0QI.json
@@ -72,11 +72,6 @@
       "Value": "Q"
     },
     {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Summons immobile serpentine wards to attack the caster\u0027s enemies. The wards are immune to magic. |nLasts \u003CArsw,Dur1\u003E seconds. |n|n|cffffcc00Attacks land and air units.|r |n|n|cffffcc00Level 1|r - \u003CArsw,DataA1\u003E wards, \u003Cosp1,realHP\u003E hit points, \u003Cosp1,mindmg1\u003E - \u003Cosp1,maxdmg1\u003E damage. |n|cffffcc00Level 2|r - \u003CArsw,DataA2\u003E wards, \u003Cosp2,realHP\u003E hit points, \u003Cosp2,mindmg1\u003E - \u003Cosp2,maxdmg1\u003E damage. |n|cffffcc00Level 3|r - \u003CArsw,DataA3\u003E wards, \u003Cosp3,realHP\u003E hit points, \u003Cosp3,mindmg1\u003E - \u003Cosp3,maxdmg1\u003E damage. |n|cffffcc00Level 4|r - \u003CArsw,DataA4\u003E wards, \u003Cosp4,realHP\u003E hit points, \u003Cosp4,mindmg1\u003E - \u003Cosp4,maxdmg1\u003E damage."
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A0QI.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0QI.json
@@ -11,39 +11,6 @@
       "Value": 0
     },
     {
-      "Level": 2,
-      "Id": "amcs",
-      "Value": 90
-    },
-    {
-      "Level": 3,
-      "Id": "amcs",
-      "Value": 105
-    },
-    {
-      "Level": 4,
-      "Id": "amcs",
-      "Value": 120
-    },
-    {
-      "Level": 2,
-      "Pointer": 1,
-      "Id": "Hwe2",
-      "Value": 4
-    },
-    {
-      "Level": 3,
-      "Pointer": 1,
-      "Id": "Hwe2",
-      "Value": 4
-    },
-    {
-      "Level": 4,
-      "Pointer": 1,
-      "Id": "Hwe2",
-      "Value": 4
-    },
-    {
       "Level": 1,
       "Id": "Hwe1",
       "Type": 3,
@@ -116,46 +83,10 @@
       "Value": "Deploy Trebuchet"
     },
     {
-      "Level": 2,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Serpent Ward (|cffffcc00Q|r) - [|cffffcc00Level 2|r]"
-    },
-    {
-      "Level": 3,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Serpent Ward (|cffffcc00Q|r) - [|cffffcc00Level 3|r]"
-    },
-    {
-      "Level": 4,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Serpent Ward (|cffffcc00Q|r) - [|cffffcc00Level 4|r]"
-    },
-    {
       "Level": 1,
       "Id": "aub1",
       "Type": 3,
       "Value": "Summons 1 immobile siege weapon to attack your enemies. The trebuchet has 1025 hit points and deals 92-119 damage. |nLasts 30 seconds. |n|n|cffffcc00Attacks land units.|r"
-    },
-    {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Summons \u003CArsw,DataA2\u003E immobile serpentine wards to attack enemies. The ward has \u003Cosp2,realHP\u003E hit points, is magic immune, and deals \u003Cosp2,mindmg1\u003E - \u003Cosp2,maxdmg1\u003E damage. |nLasts \u003CArsw,Dur2\u003E seconds. |n|n|cffffcc00Attacks land and air units.|r"
-    },
-    {
-      "Level": 3,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Summons \u003CArsw,DataA3\u003E immobile serpentine wards to attack enemies. The ward has \u003Cosp3,realHP\u003E hit points, is magic immune, and deals \u003Cosp3,mindmg1\u003E - \u003Cosp3,maxdmg1\u003E damage. |nLasts \u003CArsw,Dur3\u003E seconds. |n|n|cffffcc00Attacks land and air units.|r"
-    },
-    {
-      "Level": 4,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Summons \u003CArsw,DataA4\u003E immobile serpentine wards to attack enemies. The ward has \u003Cosp4,realHP\u003E hit points, is magic immune, and deals \u003Cosp4,mindmg1\u003E - \u003Cosp4,maxdmg1\u003E damage. |nLasts \u003CArsw,Dur4\u003E seconds. |n|n|cffffcc00Attacks land and air units.|r"
     },
     {
       "Id": "anam",

--- a/mapdata/WarcraftLegacies/AbilityData/A0RB.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0RB.json
@@ -12,43 +12,7 @@
       "Value": 120
     },
     {
-      "Level": 2,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 45
-    },
-    {
-      "Level": 3,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 45
-    },
-    {
-      "Level": 2,
-      "Id": "amcs",
-      "Value": 250
-    },
-    {
-      "Level": 3,
-      "Id": "amcs",
-      "Value": 350
-    },
-    {
       "Level": 1,
-      "Pointer": 1,
-      "Id": "Ncl1",
-      "Type": 2,
-      "Value": 300
-    },
-    {
-      "Level": 2,
-      "Pointer": 1,
-      "Id": "Ncl1",
-      "Type": 2,
-      "Value": 300
-    },
-    {
-      "Level": 3,
       "Pointer": 1,
       "Id": "Ncl1",
       "Type": 2,
@@ -61,31 +25,7 @@
       "Value": 17
     },
     {
-      "Level": 2,
-      "Pointer": 3,
-      "Id": "Ncl3",
-      "Value": 17
-    },
-    {
-      "Level": 3,
-      "Pointer": 3,
-      "Id": "Ncl3",
-      "Value": 17
-    },
-    {
       "Level": 1,
-      "Pointer": 5,
-      "Id": "Ncl5",
-      "Value": 0
-    },
-    {
-      "Level": 2,
-      "Pointer": 5,
-      "Id": "Ncl5",
-      "Value": 0
-    },
-    {
-      "Level": 3,
       "Pointer": 5,
       "Id": "Ncl5",
       "Value": 0
@@ -98,47 +38,9 @@
       "Value": "cripple"
     },
     {
-      "Level": 2,
-      "Pointer": 6,
-      "Id": "Ncl6",
-      "Type": 3,
-      "Value": "corrosivebreath"
-    },
-    {
-      "Level": 3,
-      "Pointer": 6,
-      "Id": "Ncl6",
-      "Type": 3,
-      "Value": "corrosivebreath"
-    },
-    {
       "Id": "arac",
       "Type": 3,
       "Value": "orc"
-    },
-    {
-      "Level": 2,
-      "Id": "aran",
-      "Type": 2,
-      "Value": 6000
-    },
-    {
-      "Level": 3,
-      "Id": "aran",
-      "Type": 2,
-      "Value": 9000
-    },
-    {
-      "Level": 2,
-      "Pointer": 2,
-      "Id": "Ncl2",
-      "Value": 2
-    },
-    {
-      "Level": 3,
-      "Pointer": 2,
-      "Id": "Ncl2",
-      "Value": 2
     },
     {
       "Id": "aher",
@@ -229,34 +131,10 @@
       "Value": "Portal to Argus"
     },
     {
-      "Level": 2,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Slipstream - [|cffffcc00Level 2|r]"
-    },
-    {
-      "Level": 3,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Slipstream - [|cffffcc00Level 3|r]"
-    },
-    {
       "Level": 1,
       "Id": "aub1",
       "Type": 3,
       "Value": "Opens a two-way portal to Argus. The portal becomes usable after 20 seconds, and closes 10 seconds after the caster stops channeling."
-    },
-    {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Opens a two-way portal to the target location within a range of \u003CA00D,Rng2\u003E. The portal becomes usable after 5 seconds, and closes 20 seconds after the caster stops channeling."
-    },
-    {
-      "Level": 3,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Opens a two-way portal to the target location within a range of \u003CA00D,Rng3\u003E. The portal becomes usable after 5 seconds, and closes 30 seconds after the caster stops channeling."
     },
     {
       "Id": "abpy",

--- a/mapdata/WarcraftLegacies/AbilityData/A0RB.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0RB.json
@@ -96,11 +96,6 @@
       "Value": "Portal to Argus"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTNWarpPortal.blp"
-    },
-    {
       "Id": "arpx",
       "Value": 3
     },
@@ -108,16 +103,6 @@
       "Id": "arhk",
       "Type": 3,
       "Value": "R"
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Slipstream - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Opens a two-way portal to the target location. The portal becomes usable after 5 seconds, and closes 10 seconds after the caster stops channeling.|n|n|cffffcc00Level 1|r - \u003CA00D,Rng1\u003E range. |n|cffffcc00Level 2|r - \u003CA00D,Rng2\u003E range. |n|cffffcc00Level 3|r - \u003CA00D,Rng3\u003E range."
     },
     {
       "Id": "atat",

--- a/mapdata/WarcraftLegacies/AbilityData/A0RO.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0RO.json
@@ -58,11 +58,6 @@
       "Value": "Summon Queen of Suffering"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTNLavaSpawn.blp"
-    },
-    {
       "Id": "arpx",
       "Value": 1
     },
@@ -70,16 +65,6 @@
       "Id": "arhk",
       "Type": 3,
       "Value": "W"
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Ritual of Fire - [|cffffcc00Level %d|r]."
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Dargan performs a ritual that opens a portal allowing Fire Elementals to fight his enemies. |nThe Fire Elementals last 60 seconds. |n|n|cffffcc00Level 1|r - 3 Fire Elementals with Immolation and Incinerate.|n|cffffcc00Level 2|r - 4 Fire Elementals with Immolation and Incinerate.|n|cffffcc00Level 3|r - 4 Strong Fire Elementals with Immolation, Incinerate, and Breath of Fire.|n|cffffcc00Level 4|r - 5 Strong Fire Elementals with Immolation, Incinerate, and Breath of Fire."
     },
     {
       "Level": 1,

--- a/mapdata/WarcraftLegacies/AbilityData/A0SL.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0SL.json
@@ -64,11 +64,6 @@
       "Value": "Crimson Renewal"
     },
     {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "|cff7777aaHoly Light|r |cff7777aa[E]|r"
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A0SR.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0SR.json
@@ -12,43 +12,7 @@
       "Value": 120
     },
     {
-      "Level": 2,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 45
-    },
-    {
-      "Level": 3,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 45
-    },
-    {
-      "Level": 2,
-      "Id": "amcs",
-      "Value": 250
-    },
-    {
-      "Level": 3,
-      "Id": "amcs",
-      "Value": 350
-    },
-    {
       "Level": 1,
-      "Pointer": 1,
-      "Id": "Ncl1",
-      "Type": 2,
-      "Value": 300
-    },
-    {
-      "Level": 2,
-      "Pointer": 1,
-      "Id": "Ncl1",
-      "Type": 2,
-      "Value": 300
-    },
-    {
-      "Level": 3,
       "Pointer": 1,
       "Id": "Ncl1",
       "Type": 2,
@@ -61,31 +25,7 @@
       "Value": 17
     },
     {
-      "Level": 2,
-      "Pointer": 3,
-      "Id": "Ncl3",
-      "Value": 17
-    },
-    {
-      "Level": 3,
-      "Pointer": 3,
-      "Id": "Ncl3",
-      "Value": 17
-    },
-    {
       "Level": 1,
-      "Pointer": 5,
-      "Id": "Ncl5",
-      "Value": 0
-    },
-    {
-      "Level": 2,
-      "Pointer": 5,
-      "Id": "Ncl5",
-      "Value": 0
-    },
-    {
-      "Level": 3,
       "Pointer": 5,
       "Id": "Ncl5",
       "Value": 0
@@ -98,47 +38,9 @@
       "Value": "earthquake"
     },
     {
-      "Level": 2,
-      "Pointer": 6,
-      "Id": "Ncl6",
-      "Type": 3,
-      "Value": "corrosivebreath"
-    },
-    {
-      "Level": 3,
-      "Pointer": 6,
-      "Id": "Ncl6",
-      "Type": 3,
-      "Value": "corrosivebreath"
-    },
-    {
       "Id": "arac",
       "Type": 3,
       "Value": "orc"
-    },
-    {
-      "Level": 2,
-      "Id": "aran",
-      "Type": 2,
-      "Value": 6000
-    },
-    {
-      "Level": 3,
-      "Id": "aran",
-      "Type": 2,
-      "Value": 9000
-    },
-    {
-      "Level": 2,
-      "Pointer": 2,
-      "Id": "Ncl2",
-      "Value": 2
-    },
-    {
-      "Level": 3,
-      "Pointer": 2,
-      "Id": "Ncl2",
-      "Value": 2
     },
     {
       "Id": "aher",
@@ -229,34 +131,10 @@
       "Value": "Portal to Tempest Keep"
     },
     {
-      "Level": 2,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Slipstream - [|cffffcc00Level 2|r]"
-    },
-    {
-      "Level": 3,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Slipstream - [|cffffcc00Level 3|r]"
-    },
-    {
       "Level": 1,
       "Id": "aub1",
       "Type": 3,
       "Value": "Opens a two-way portal to Tempest Keep. The portal becomes usable after 20 seconds, and closes 10 seconds after the caster stops channeling."
-    },
-    {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Opens a two-way portal to the target location within a range of \u003CA00D,Rng2\u003E. The portal becomes usable after 5 seconds, and closes 20 seconds after the caster stops channeling."
-    },
-    {
-      "Level": 3,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Opens a two-way portal to the target location within a range of \u003CA00D,Rng3\u003E. The portal becomes usable after 5 seconds, and closes 30 seconds after the caster stops channeling."
     },
     {
       "Id": "abpx",

--- a/mapdata/WarcraftLegacies/AbilityData/A0SR.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0SR.json
@@ -96,11 +96,6 @@
       "Value": "Portal to Tempest Keep"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTNWarpPortal.blp"
-    },
-    {
       "Id": "arpx",
       "Value": 3
     },
@@ -108,16 +103,6 @@
       "Id": "arhk",
       "Type": 3,
       "Value": "R"
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Slipstream - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Opens a two-way portal to the target location. The portal becomes usable after 5 seconds, and closes 10 seconds after the caster stops channeling.|n|n|cffffcc00Level 1|r - \u003CA00D,Rng1\u003E range. |n|cffffcc00Level 2|r - \u003CA00D,Rng2\u003E range. |n|cffffcc00Level 3|r - \u003CA00D,Rng3\u003E range."
     },
     {
       "Id": "atat",

--- a/mapdata/WarcraftLegacies/AbilityData/A0T5.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0T5.json
@@ -21,12 +21,6 @@
       "Value": "Teleporters will be activated when the Argus Incursion quest is completed. They are temporary structures that will destroy themselves after 20 turns. |n|nThey cannot be repaired or healed so use them well before then!"
     },
     {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Increases the rate at which this unit gathers lumber."
-    },
-    {
       "Id": "aart",
       "Type": 3,
       "Value": "ReplaceableTextures\\CommandButtons\\PASSoulBinding.blp"

--- a/mapdata/WarcraftLegacies/AbilityData/A0T7.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0T7.json
@@ -64,11 +64,6 @@
       "Value": "Greater Holy Light"
     },
     {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "|cff7777aaHoly Light|r |cff7777aa[E]|r"
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A0T8.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0T8.json
@@ -45,11 +45,6 @@
       "Value": "W"
     },
     {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Reveals the area of the map that it is cast upon. Also reveals invisible units. |n|n|cffffcc00Level 1|r - Reveals a small area for \u003CAOfs,Cost1\u003E mana. |n|cffffcc00Level 2|r - Reveals a large area for \u003CAOfs,Cost2\u003E mana. |n|cffffcc00Level 3|r - Reveals a very large area for \u003CAOfs,Cost3\u003E mana.|n|cffffcc00Level 4|r - Reveals a huge area for \u003CAOfs,Cost4\u003E mana.|n|cffffcc00Level 5|r - Reveals a massive area for \u003CAOfs,Cost5\u003E mana."
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A0TO.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0TO.json
@@ -93,11 +93,6 @@
       "Value": "W"
     },
     {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Summons \u003CAOsf,DataB1\u003E Spirit Wolves to fight the Far Seer\u0027s enemies. |nLasts \u003CAOsf,Dur1\u003E seconds. |n|n|cffffcc00Level 1|r - \u003Cosw1,realHP\u003E hit points, \u003Cosw1,mindmg1\u003E - \u003Cosw1,maxdmg1\u003E damage. 2 wolves summoned.|n|cffffcc00Level 2|r - \u003Cosw2,realHP\u003E hit points, \u003Cosw2,mindmg1\u003E - \u003Cosw2,maxdmg1\u003E damage and Critical Strike. 2 wolves summoned.|n|cffffcc00Level 3|r - \u003Cosw3,realHP\u003E hit points, \u003Cosw3,mindmg1\u003E - \u003Cosw3,maxdmg1\u003E damage and Critical Strike. 2 wolves summoned.|n|cffffcc00Level 4|r - \u003Cosw3,realHP\u003E hit points, \u003Cosw3,mindmg1\u003E - \u003Cosw3,maxdmg1\u003E damage, and Critical Strike. 4 wolves summoned.|n|cffffcc00Level 5|r - \u003Cosw3,realHP\u003E hit points, \u003Cosw3,mindmg1\u003E - \u003Cosw3,maxdmg1\u003E damage and Critical Strike. 6 wolves summoned.|n"
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A0UB.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0UB.json
@@ -6,43 +6,7 @@
   ],
   "Modifications": [
     {
-      "Level": 2,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 45
-    },
-    {
-      "Level": 3,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 45
-    },
-    {
-      "Level": 2,
-      "Id": "amcs",
-      "Value": 250
-    },
-    {
-      "Level": 3,
-      "Id": "amcs",
-      "Value": 350
-    },
-    {
       "Level": 1,
-      "Pointer": 1,
-      "Id": "Ncl1",
-      "Type": 2,
-      "Value": 300
-    },
-    {
-      "Level": 2,
-      "Pointer": 1,
-      "Id": "Ncl1",
-      "Type": 2,
-      "Value": 300
-    },
-    {
-      "Level": 3,
       "Pointer": 1,
       "Id": "Ncl1",
       "Type": 2,
@@ -55,31 +19,7 @@
       "Value": 17
     },
     {
-      "Level": 2,
-      "Pointer": 3,
-      "Id": "Ncl3",
-      "Value": 17
-    },
-    {
-      "Level": 3,
-      "Pointer": 3,
-      "Id": "Ncl3",
-      "Value": 17
-    },
-    {
       "Level": 1,
-      "Pointer": 5,
-      "Id": "Ncl5",
-      "Value": 0
-    },
-    {
-      "Level": 2,
-      "Pointer": 5,
-      "Id": "Ncl5",
-      "Value": 0
-    },
-    {
-      "Level": 3,
       "Pointer": 5,
       "Id": "Ncl5",
       "Value": 0
@@ -92,47 +32,9 @@
       "Value": "cripple"
     },
     {
-      "Level": 2,
-      "Pointer": 6,
-      "Id": "Ncl6",
-      "Type": 3,
-      "Value": "corrosivebreath"
-    },
-    {
-      "Level": 3,
-      "Pointer": 6,
-      "Id": "Ncl6",
-      "Type": 3,
-      "Value": "corrosivebreath"
-    },
-    {
       "Id": "arac",
       "Type": 3,
       "Value": "orc"
-    },
-    {
-      "Level": 2,
-      "Id": "aran",
-      "Type": 2,
-      "Value": 6000
-    },
-    {
-      "Level": 3,
-      "Id": "aran",
-      "Type": 2,
-      "Value": 9000
-    },
-    {
-      "Level": 2,
-      "Pointer": 2,
-      "Id": "Ncl2",
-      "Value": 2
-    },
-    {
-      "Level": 3,
-      "Pointer": 2,
-      "Id": "Ncl2",
-      "Value": 2
     },
     {
       "Id": "aher",
@@ -229,34 +131,10 @@
       "Value": "Portal to Northrend"
     },
     {
-      "Level": 2,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Slipstream - [|cffffcc00Level 2|r]"
-    },
-    {
-      "Level": 3,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Slipstream - [|cffffcc00Level 3|r]"
-    },
-    {
       "Level": 1,
       "Id": "aub1",
       "Type": 3,
       "Value": "Opens a two-way portal to Northrend. The portal becomes usable after 10 seconds, and closes 5 seconds after the caster stops channeling."
-    },
-    {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Opens a two-way portal to the target location within a range of \u003CA00D,Rng2\u003E. The portal becomes usable after 5 seconds, and closes 20 seconds after the caster stops channeling."
-    },
-    {
-      "Level": 3,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Opens a two-way portal to the target location within a range of \u003CA00D,Rng3\u003E. The portal becomes usable after 5 seconds, and closes 30 seconds after the caster stops channeling."
     },
     {
       "Id": "abpy",

--- a/mapdata/WarcraftLegacies/AbilityData/A0UB.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0UB.json
@@ -96,11 +96,6 @@
       "Value": "Portal to Northrend"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTNWarpPortal.blp"
-    },
-    {
       "Id": "arpx",
       "Value": 3
     },
@@ -108,16 +103,6 @@
       "Id": "arhk",
       "Type": 3,
       "Value": "R"
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Slipstream - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Opens a two-way portal to the target location. The portal becomes usable after 5 seconds, and closes 10 seconds after the caster stops channeling.|n|n|cffffcc00Level 1|r - \u003CA00D,Rng1\u003E range. |n|cffffcc00Level 2|r - \u003CA00D,Rng2\u003E range. |n|cffffcc00Level 3|r - \u003CA00D,Rng3\u003E range."
     },
     {
       "Id": "atat",

--- a/mapdata/WarcraftLegacies/AbilityData/A0UC.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0UC.json
@@ -6,43 +6,7 @@
   ],
   "Modifications": [
     {
-      "Level": 2,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 45
-    },
-    {
-      "Level": 3,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 45
-    },
-    {
-      "Level": 2,
-      "Id": "amcs",
-      "Value": 250
-    },
-    {
-      "Level": 3,
-      "Id": "amcs",
-      "Value": 350
-    },
-    {
       "Level": 1,
-      "Pointer": 1,
-      "Id": "Ncl1",
-      "Type": 2,
-      "Value": 300
-    },
-    {
-      "Level": 2,
-      "Pointer": 1,
-      "Id": "Ncl1",
-      "Type": 2,
-      "Value": 300
-    },
-    {
-      "Level": 3,
       "Pointer": 1,
       "Id": "Ncl1",
       "Type": 2,
@@ -55,51 +19,13 @@
       "Value": 17
     },
     {
-      "Level": 2,
-      "Pointer": 3,
-      "Id": "Ncl3",
-      "Value": 17
-    },
-    {
-      "Level": 3,
-      "Pointer": 3,
-      "Id": "Ncl3",
-      "Value": 17
-    },
-    {
       "Level": 1,
       "Pointer": 5,
       "Id": "Ncl5",
       "Value": 0
     },
     {
-      "Level": 2,
-      "Pointer": 5,
-      "Id": "Ncl5",
-      "Value": 0
-    },
-    {
-      "Level": 3,
-      "Pointer": 5,
-      "Id": "Ncl5",
-      "Value": 0
-    },
-    {
       "Level": 1,
-      "Pointer": 6,
-      "Id": "Ncl6",
-      "Type": 3,
-      "Value": "corrosivebreath"
-    },
-    {
-      "Level": 2,
-      "Pointer": 6,
-      "Id": "Ncl6",
-      "Type": 3,
-      "Value": "corrosivebreath"
-    },
-    {
-      "Level": 3,
       "Pointer": 6,
       "Id": "Ncl6",
       "Type": 3,
@@ -109,30 +35,6 @@
       "Id": "arac",
       "Type": 3,
       "Value": "orc"
-    },
-    {
-      "Level": 2,
-      "Id": "aran",
-      "Type": 2,
-      "Value": 6000
-    },
-    {
-      "Level": 3,
-      "Id": "aran",
-      "Type": 2,
-      "Value": 9000
-    },
-    {
-      "Level": 2,
-      "Pointer": 2,
-      "Id": "Ncl2",
-      "Value": 2
-    },
-    {
-      "Level": 3,
-      "Pointer": 2,
-      "Id": "Ncl2",
-      "Value": 2
     },
     {
       "Id": "aher",
@@ -229,34 +131,10 @@
       "Value": "Portal to Alterac"
     },
     {
-      "Level": 2,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Slipstream - [|cffffcc00Level 2|r]"
-    },
-    {
-      "Level": 3,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Slipstream - [|cffffcc00Level 3|r]"
-    },
-    {
       "Level": 1,
       "Id": "aub1",
       "Type": 3,
       "Value": "Opens a two-way portal to Alterac. The portal becomes usable after 10 seconds, and closes 45 seconds after the caster stops channeling."
-    },
-    {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Opens a two-way portal to the target location within a range of \u003CA00D,Rng2\u003E. The portal becomes usable after 5 seconds, and closes 20 seconds after the caster stops channeling."
-    },
-    {
-      "Level": 3,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Opens a two-way portal to the target location within a range of \u003CA00D,Rng3\u003E. The portal becomes usable after 5 seconds, and closes 30 seconds after the caster stops channeling."
     },
     {
       "Id": "abpy",

--- a/mapdata/WarcraftLegacies/AbilityData/A0UC.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0UC.json
@@ -96,11 +96,6 @@
       "Value": "Portal to Alterac"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTNWarpPortal.blp"
-    },
-    {
       "Id": "arpx",
       "Value": 3
     },
@@ -108,16 +103,6 @@
       "Id": "arhk",
       "Type": 3,
       "Value": "R"
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Slipstream - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Opens a two-way portal to the target location. The portal becomes usable after 5 seconds, and closes 10 seconds after the caster stops channeling.|n|n|cffffcc00Level 1|r - \u003CA00D,Rng1\u003E range. |n|cffffcc00Level 2|r - \u003CA00D,Rng2\u003E range. |n|cffffcc00Level 3|r - \u003CA00D,Rng3\u003E range."
     },
     {
       "Id": "atat",

--- a/mapdata/WarcraftLegacies/AbilityData/A0UU.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0UU.json
@@ -6,46 +6,11 @@
   ],
   "Modifications": [
     {
-      "Level": 3,
-      "Pointer": 1,
-      "Id": "War1",
-      "Type": 2,
-      "Value": 25
-    },
-    {
       "Level": 1,
       "Pointer": 2,
       "Id": "War2",
       "Type": 2,
       "Value": 60
-    },
-    {
-      "Level": 2,
-      "Pointer": 2,
-      "Id": "War2",
-      "Type": 2,
-      "Value": 75
-    },
-    {
-      "Level": 3,
-      "Pointer": 2,
-      "Id": "War2",
-      "Type": 2,
-      "Value": 100
-    },
-    {
-      "Level": 3,
-      "Pointer": 3,
-      "Id": "War3",
-      "Type": 2,
-      "Value": 250
-    },
-    {
-      "Level": 3,
-      "Pointer": 4,
-      "Id": "War4",
-      "Type": 2,
-      "Value": 350
     },
     {
       "Id": "alev",
@@ -55,12 +20,6 @@
       "Id": "arac",
       "Type": 3,
       "Value": "human"
-    },
-    {
-      "Level": 3,
-      "Id": "atar",
-      "Type": 3,
-      "Value": "ground,enemy,neutral"
     },
     {
       "Level": 1,
@@ -106,34 +65,10 @@
       "Value": "Righteous Fury"
     },
     {
-      "Level": 2,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Pulverize - [|cffffcc00Level 2|r]"
-    },
-    {
-      "Level": 3,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Pulverize - [|cffffcc00Level 3|r]"
-    },
-    {
       "Level": 1,
       "Id": "aub1",
       "Type": 3,
       "Value": "Gives a 25% chance that an attack will deal 60 damage to nearby units in a large area."
-    },
-    {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Gives a 25% chance that an attack will deal 75 damage to nearby units."
-    },
-    {
-      "Level": 3,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Gives a 25% chance that an attack will deal 100 damage to nearby units."
     },
     {
       "Id": "anam",

--- a/mapdata/WarcraftLegacies/AbilityData/A0V0.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0V0.json
@@ -12,63 +12,15 @@
       "Value": 2
     },
     {
-      "Level": 2,
-      "Id": "acas",
-      "Type": 2,
-      "Value": 5
-    },
-    {
-      "Level": 3,
-      "Id": "acas",
-      "Type": 2,
-      "Value": 5
-    },
-    {
       "Level": 1,
       "Id": "acdn",
       "Type": 2,
       "Value": 90
     },
     {
-      "Level": 2,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 40
-    },
-    {
-      "Level": 3,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 40
-    },
-    {
       "Level": 1,
       "Id": "amcs",
       "Value": 0
-    },
-    {
-      "Level": 2,
-      "Id": "amcs",
-      "Value": 250
-    },
-    {
-      "Level": 3,
-      "Id": "amcs",
-      "Value": 250
-    },
-    {
-      "Level": 2,
-      "Pointer": 1,
-      "Id": "Htb1",
-      "Type": 2,
-      "Value": 600
-    },
-    {
-      "Level": 3,
-      "Pointer": 1,
-      "Id": "Htb1",
-      "Type": 2,
-      "Value": 800
     },
     {
       "Level": 1,
@@ -77,28 +29,10 @@
       "Value": 4
     },
     {
-      "Level": 3,
-      "Id": "adur",
-      "Type": 2,
-      "Value": 6
-    },
-    {
       "Level": 1,
       "Id": "ahdu",
       "Type": 2,
       "Value": 0.5
-    },
-    {
-      "Level": 2,
-      "Id": "ahdu",
-      "Type": 2,
-      "Value": 0.9
-    },
-    {
-      "Level": 3,
-      "Id": "ahdu",
-      "Type": 2,
-      "Value": 1
     },
     {
       "Id": "alsk",
@@ -117,18 +51,6 @@
       "Id": "aran",
       "Type": 2,
       "Value": 1500
-    },
-    {
-      "Level": 2,
-      "Id": "aran",
-      "Type": 2,
-      "Value": 2000
-    },
-    {
-      "Level": 3,
-      "Id": "aran",
-      "Type": 2,
-      "Value": 2000
     },
     {
       "Id": "aher",
@@ -206,34 +128,10 @@
       "Value": "Snipe"
     },
     {
-      "Level": 2,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Assassinate - [|cffffcc00Level 2|r]"
-    },
-    {
-      "Level": 3,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Assassinate - [|cffffcc00Level 3|r]"
-    },
-    {
       "Level": 1,
       "Id": "aub1",
       "Type": 3,
       "Value": "The unit takes aim and fires at an enemy unit, causing 75 damage and stunning the targe for 4 seconds (0.5 on heroes)."
-    },
-    {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "The hero takes aim and fires at an enemy unit, causing damage and stunning the target.|n|cffffcc00Level 2|r - 600 damage, 5 second stun. .9 seconds on Heroes."
-    },
-    {
-      "Level": 3,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "The hero takes aim and fires at an enemy unit, causing damage and stunning the target. |n|cffffcc00Level 3|r - 800 damage, 6 second stun. 1 seconds on Heroes."
     }
   ]
 }

--- a/mapdata/WarcraftLegacies/AbilityData/A0V0.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0V0.json
@@ -98,11 +98,6 @@
       "Value": "Snipe"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTNHumanMissileUpOne.blp"
-    },
-    {
       "Id": "arpx",
       "Value": 3
     },
@@ -110,16 +105,6 @@
       "Id": "arhk",
       "Type": 3,
       "Value": "R"
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Assassinate - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "The hero takes aim and fires at an enemy unit, causing damage and stunning the target. |n|n|cffffcc00Level 1|r - 450 damage, 4 second stun. .8 second on Heroes.|n|cffffcc00Level 2|r - 600 damage, 5 second stun. .9 seconds on Heroes.|n|cffffcc00Level 3|r - 800 damage, 6 second stun. 1 seconds on Heroes."
     },
     {
       "Level": 1,

--- a/mapdata/WarcraftLegacies/AbilityData/A0V1.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0V1.json
@@ -69,11 +69,6 @@
       "Value": "Healing Surge"
     },
     {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "|cff7777aaHoly Light|r |cff7777aa[E]|r"
-    },
-    {
       "Id": "atat",
       "Type": 3,
       "Value": "Abilities\\Spells\\Items\\RitualDagger\\RitualDaggerTarget.mdl"

--- a/mapdata/WarcraftLegacies/AbilityData/A0W5.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0W5.json
@@ -17,11 +17,6 @@
       "Value": 75
     },
     {
-      "Level": 2,
-      "Id": "amcs",
-      "Value": 100
-    },
-    {
       "Level": 1,
       "Pointer": 1,
       "Id": "Nso1",
@@ -29,21 +24,7 @@
       "Value": 7.5
     },
     {
-      "Level": 2,
-      "Pointer": 1,
-      "Id": "Nso1",
-      "Type": 2,
-      "Value": 10
-    },
-    {
       "Level": 1,
-      "Pointer": 4,
-      "Id": "Nso4",
-      "Type": 2,
-      "Value": 0.75
-    },
-    {
-      "Level": 2,
       "Pointer": 4,
       "Id": "Nso4",
       "Type": 2,
@@ -57,20 +38,7 @@
       "Value": 0.5
     },
     {
-      "Level": 2,
-      "Pointer": 5,
-      "Id": "Nso5",
-      "Type": 2,
-      "Value": 0.5
-    },
-    {
       "Level": 1,
-      "Id": "adur",
-      "Type": 2,
-      "Value": 45
-    },
-    {
-      "Level": 2,
       "Id": "adur",
       "Type": 2,
       "Value": 45
@@ -81,12 +49,6 @@
     },
     {
       "Level": 1,
-      "Id": "ahdu",
-      "Type": 2,
-      "Value": 3
-    },
-    {
-      "Level": 2,
       "Id": "ahdu",
       "Type": 2,
       "Value": 3
@@ -124,12 +86,6 @@
       "Id": "aub1",
       "Type": 3,
       "Value": "Wreaths an enemy unit in magical flames which cause 7.5 damage per second, prevent the casting of spells, reduce movement speed by 75% and reduce attack damage and attack speed by 50%.|nLasts 45(3) seconds."
-    },
-    {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Wreaths an enemy unit in magical flames which causes 10 damage per second, prevent the casting of spells, reduce movement speed by 75% and reduce attack damage and attack speed by 50%.|nLasts 45(3) seconds."
     },
     {
       "Level": 1,

--- a/mapdata/WarcraftLegacies/AbilityData/A0W9.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0W9.json
@@ -12,61 +12,12 @@
       "Value": 60
     },
     {
-      "Level": 2,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 60
-    },
-    {
-      "Level": 3,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 60
-    },
-    {
-      "Level": 4,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 60
-    },
-    {
       "Level": 1,
       "Id": "amcs",
       "Value": 50
     },
     {
-      "Level": 2,
-      "Id": "amcs",
-      "Value": 135
-    },
-    {
-      "Level": 4,
-      "Id": "amcs",
-      "Value": 155
-    },
-    {
       "Level": 1,
-      "Pointer": 1,
-      "Id": "Ncl1",
-      "Type": 2,
-      "Value": 0.5
-    },
-    {
-      "Level": 2,
-      "Pointer": 1,
-      "Id": "Ncl1",
-      "Type": 2,
-      "Value": 0.5
-    },
-    {
-      "Level": 3,
-      "Pointer": 1,
-      "Id": "Ncl1",
-      "Type": 2,
-      "Value": 0.5
-    },
-    {
-      "Level": 4,
       "Pointer": 1,
       "Id": "Ncl1",
       "Type": 2,
@@ -79,37 +30,7 @@
       "Value": 17
     },
     {
-      "Level": 3,
-      "Pointer": 3,
-      "Id": "Ncl3",
-      "Value": 17
-    },
-    {
-      "Level": 4,
-      "Pointer": 3,
-      "Id": "Ncl3",
-      "Value": 17
-    },
-    {
       "Level": 1,
-      "Pointer": 5,
-      "Id": "Ncl5",
-      "Value": 0
-    },
-    {
-      "Level": 2,
-      "Pointer": 5,
-      "Id": "Ncl5",
-      "Value": 0
-    },
-    {
-      "Level": 3,
-      "Pointer": 5,
-      "Id": "Ncl5",
-      "Value": 0
-    },
-    {
-      "Level": 4,
       "Pointer": 5,
       "Id": "Ncl5",
       "Value": 0
@@ -122,27 +43,6 @@
       "Value": "darkconversion"
     },
     {
-      "Level": 2,
-      "Pointer": 6,
-      "Id": "Ncl6",
-      "Type": 3,
-      "Value": "howlofterror"
-    },
-    {
-      "Level": 3,
-      "Pointer": 6,
-      "Id": "Ncl6",
-      "Type": 3,
-      "Value": "howlofterror"
-    },
-    {
-      "Level": 4,
-      "Pointer": 6,
-      "Id": "Ncl6",
-      "Type": 3,
-      "Value": "howlofterror"
-    },
-    {
       "Id": "arac",
       "Type": 3,
       "Value": "undead"
@@ -150,17 +50,6 @@
     {
       "Id": "alev",
       "Value": 1
-    },
-    {
-      "Level": 3,
-      "Id": "amcs",
-      "Value": 145
-    },
-    {
-      "Level": 2,
-      "Pointer": 3,
-      "Id": "Ncl3",
-      "Value": 17
     },
     {
       "Id": "aher",
@@ -247,46 +136,10 @@
       "Value": "Death Pact"
     },
     {
-      "Level": 2,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Reap - [|cffffcc00Level 2|r]"
-    },
-    {
-      "Level": 3,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Reap - [|cffffcc00Level 3|r]"
-    },
-    {
-      "Level": 4,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Reap - [|cffffcc00Level 4|r]"
-    },
-    {
       "Level": 1,
       "Id": "aub1",
       "Type": 3,
       "Value": "Sacrifices a friendly Undead unit, giving 125% of its hit points to the Death Knight and 10% of it\u0027s hit points in mana. Prioritises summoned units."
-    },
-    {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Instantly kills the 5 lowest level non-Hero nearby enemy units, granting the caster 5 Strength for each unit slain for 30 seconds."
-    },
-    {
-      "Level": 3,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Instantly kills the 7 lowest level non-Hero nearby enemy units, granting the caster 5 Strength for each unit slain for 30 seconds."
-    },
-    {
-      "Level": 4,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Instantly kills the 9 lowest level non-Hero nearby enemy units, granting the caster 5 Strength for each unit slain for 30 seconds."
     }
   ]
 }

--- a/mapdata/WarcraftLegacies/AbilityData/A0W9.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0W9.json
@@ -101,11 +101,6 @@
       "Value": "Death Pact"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTNCursedScythe.blp"
-    },
-    {
       "Id": "arpx",
       "Value": 1
     },
@@ -113,16 +108,6 @@
       "Id": "arhk",
       "Type": 3,
       "Value": "W"
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Reap - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Instantly kills the lowest level nearby non-Hero enemy units, granting the caster 5 Strength for each unit slain for 30 seconds. |n|n|cffffcc00Level 1|r - Kills 3 units.|n|cffffcc00Level 2|r - Kills 5 units.|n|cffffcc00Level 3|r - Kills 7 units.|n|cffffcc00Level 4|r - Kills 9 units."
     },
     {
       "Id": "atat",

--- a/mapdata/WarcraftLegacies/AbilityData/A0WP.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0WP.json
@@ -101,11 +101,6 @@
       "Value": "Dark Ritual"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTNCursedScythe.blp"
-    },
-    {
       "Id": "arpx",
       "Value": 1
     },
@@ -113,16 +108,6 @@
       "Id": "arhk",
       "Type": 3,
       "Value": "W"
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Reap - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Instantly kills the lowest level nearby non-Hero enemy units, granting the caster 5 Strength for each unit slain for 30 seconds. |n|n|cffffcc00Level 1|r - Kills 3 units.|n|cffffcc00Level 2|r - Kills 5 units.|n|cffffcc00Level 3|r - Kills 7 units.|n|cffffcc00Level 4|r - Kills 9 units."
     },
     {
       "Id": "atat",

--- a/mapdata/WarcraftLegacies/AbilityData/A0WP.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0WP.json
@@ -12,61 +12,12 @@
       "Value": 20
     },
     {
-      "Level": 2,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 60
-    },
-    {
-      "Level": 3,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 60
-    },
-    {
-      "Level": 4,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 60
-    },
-    {
       "Level": 1,
       "Id": "amcs",
       "Value": 25
     },
     {
-      "Level": 2,
-      "Id": "amcs",
-      "Value": 135
-    },
-    {
-      "Level": 4,
-      "Id": "amcs",
-      "Value": 155
-    },
-    {
       "Level": 1,
-      "Pointer": 1,
-      "Id": "Ncl1",
-      "Type": 2,
-      "Value": 0.5
-    },
-    {
-      "Level": 2,
-      "Pointer": 1,
-      "Id": "Ncl1",
-      "Type": 2,
-      "Value": 0.5
-    },
-    {
-      "Level": 3,
-      "Pointer": 1,
-      "Id": "Ncl1",
-      "Type": 2,
-      "Value": 0.5
-    },
-    {
-      "Level": 4,
       "Pointer": 1,
       "Id": "Ncl1",
       "Type": 2,
@@ -79,64 +30,13 @@
       "Value": 17
     },
     {
-      "Level": 3,
-      "Pointer": 3,
-      "Id": "Ncl3",
-      "Value": 17
-    },
-    {
-      "Level": 4,
-      "Pointer": 3,
-      "Id": "Ncl3",
-      "Value": 17
-    },
-    {
       "Level": 1,
       "Pointer": 5,
       "Id": "Ncl5",
       "Value": 0
     },
     {
-      "Level": 2,
-      "Pointer": 5,
-      "Id": "Ncl5",
-      "Value": 0
-    },
-    {
-      "Level": 3,
-      "Pointer": 5,
-      "Id": "Ncl5",
-      "Value": 0
-    },
-    {
-      "Level": 4,
-      "Pointer": 5,
-      "Id": "Ncl5",
-      "Value": 0
-    },
-    {
       "Level": 1,
-      "Pointer": 6,
-      "Id": "Ncl6",
-      "Type": 3,
-      "Value": "howlofterror"
-    },
-    {
-      "Level": 2,
-      "Pointer": 6,
-      "Id": "Ncl6",
-      "Type": 3,
-      "Value": "howlofterror"
-    },
-    {
-      "Level": 3,
-      "Pointer": 6,
-      "Id": "Ncl6",
-      "Type": 3,
-      "Value": "howlofterror"
-    },
-    {
-      "Level": 4,
       "Pointer": 6,
       "Id": "Ncl6",
       "Type": 3,
@@ -150,17 +50,6 @@
     {
       "Id": "alev",
       "Value": 1
-    },
-    {
-      "Level": 3,
-      "Id": "amcs",
-      "Value": 145
-    },
-    {
-      "Level": 2,
-      "Pointer": 3,
-      "Id": "Ncl3",
-      "Value": 17
     },
     {
       "Id": "aher",
@@ -247,46 +136,10 @@
       "Value": "Dark Ritual"
     },
     {
-      "Level": 2,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Reap - [|cffffcc00Level 2|r]"
-    },
-    {
-      "Level": 3,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Reap - [|cffffcc00Level 3|r]"
-    },
-    {
-      "Level": 4,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Reap - [|cffffcc00Level 4|r]"
-    },
-    {
       "Level": 1,
       "Id": "aub1",
       "Type": 3,
       "Value": "Sacrifices a friendly Undead unit, giving 35% of its hit points to the caster and 25% of it\u0027s hit points in mana. Prioritises summoned units."
-    },
-    {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Instantly kills the 5 lowest level non-Hero nearby enemy units, granting the caster 5 Strength for each unit slain for 30 seconds."
-    },
-    {
-      "Level": 3,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Instantly kills the 7 lowest level non-Hero nearby enemy units, granting the caster 5 Strength for each unit slain for 30 seconds."
-    },
-    {
-      "Level": 4,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Instantly kills the 9 lowest level non-Hero nearby enemy units, granting the caster 5 Strength for each unit slain for 30 seconds."
     },
     {
       "Id": "abpx",

--- a/mapdata/WarcraftLegacies/AbilityData/A0WZ.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0WZ.json
@@ -63,11 +63,6 @@
       "Value": "W"
     },
     {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Each attack made is enhanced with living flames that cling to the target. These flames add a small amount of damage on the first attack, twice as much on the second attack, three times as much on the third attack, etc.|n|nIf a unit dies while under this effect, it is incinerated, causing 30 damage to all nearby hostile units."
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A0XG.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0XG.json
@@ -53,11 +53,6 @@
       "Value": "W"
     },
     {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "The Crypt Lord forms barbed layers of chitinous armor that increases its defense and returns damage to enemy melee attackers.  |n|n|cffffcc00Level 1|r - \u003CAUts,DataA1,%\u003E% damage returned, \u003CAUts,DataC1\u003E bonus armor. |n|cffffcc00Level 2|r -  \u003CAUts,DataA2,%\u003E% damage returned, \u003CAUts,DataC2\u003E bonus armor. |n|cffffcc00Level 3|r -  \u003CAUts,DataA3,%\u003E% damage returned, \u003CAUts,DataC3\u003E bonus armor.  |n|cffffcc00Level 4|r -  \u003CAUts,DataA4,%\u003E% damage returned, \u003CAUts,DataC4\u003E bonus armor."
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A0Y5.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0Y5.json
@@ -6,35 +6,7 @@
   ],
   "Modifications": [
     {
-      "Level": 2,
-      "Pointer": 2,
-      "Id": "Nic2",
-      "Type": 2,
-      "Value": 60
-    },
-    {
-      "Level": 3,
-      "Pointer": 2,
-      "Id": "Nic2",
-      "Type": 2,
-      "Value": 80
-    },
-    {
       "Level": 1,
-      "Pointer": 3,
-      "Id": "Nic3",
-      "Type": 2,
-      "Value": 160
-    },
-    {
-      "Level": 2,
-      "Pointer": 3,
-      "Id": "Nic3",
-      "Type": 2,
-      "Value": 160
-    },
-    {
-      "Level": 3,
       "Pointer": 3,
       "Id": "Nic3",
       "Type": 2,
@@ -48,36 +20,10 @@
       "Value": 20
     },
     {
-      "Level": 2,
-      "Pointer": 4,
-      "Id": "Nic4",
-      "Type": 2,
-      "Value": 45
-    },
-    {
-      "Level": 3,
-      "Pointer": 4,
-      "Id": "Nic4",
-      "Type": 2,
-      "Value": 65
-    },
-    {
       "Level": 1,
       "Id": "adur",
       "Type": 2,
       "Value": 10
-    },
-    {
-      "Level": 2,
-      "Id": "adur",
-      "Type": 2,
-      "Value": 10
-    },
-    {
-      "Level": 3,
-      "Id": "adur",
-      "Type": 2,
-      "Value": 15
     },
     {
       "Id": "aher",
@@ -88,18 +34,6 @@
       "Id": "ahdu",
       "Type": 2,
       "Value": 10
-    },
-    {
-      "Level": 2,
-      "Id": "ahdu",
-      "Type": 2,
-      "Value": 10
-    },
-    {
-      "Level": 3,
-      "Id": "ahdu",
-      "Type": 2,
-      "Value": 15
     },
     {
       "Id": "amho",
@@ -135,18 +69,6 @@
       "Id": "ahky",
       "Type": 3,
       "Value": ""
-    },
-    {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Each attack made is enhanced with living flames that cling to the target. These flames add \u003CA0KC,DataA2\u003E damage on the first attack, twice as much on the second attack, three times as much on the third attack, etc.|n|nIf a unit dies while under this effect, it is incinerated, causing up to \u003CA0KC,DataB2\u003E damage to all nearby hostile units."
-    },
-    {
-      "Level": 3,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Each attack made is enhanced with living flames that cling to the target. These flames add \u003CA0KC,DataA3\u003E damage on the first attack, twice as much on the second attack, three times as much on the third attack, etc.|n|nIf a unit dies while under this effect, it is incinerated, causing up to \u003CA0KC,DataB3\u003E damage to all nearby hostile units."
     },
     {
       "Level": 1,

--- a/mapdata/WarcraftLegacies/AbilityData/A0YE.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0YE.json
@@ -47,11 +47,6 @@
       "Value": "Elite Combat Experience"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTNHeadHunterBerserker.blp"
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A0YG.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0YG.json
@@ -21,12 +21,6 @@
       "Value": "This unit has 1 goblin crewing it, he will jump out when the shredder is destroyed."
     },
     {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Increases the rate at which this unit gathers lumber."
-    },
-    {
       "Id": "aart",
       "Type": 3,
       "Value": "ReplaceableTextures\\PassiveButtons\\PASGoblinCommando.blp"

--- a/mapdata/WarcraftLegacies/AbilityData/A0YL.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0YL.json
@@ -79,21 +79,6 @@
       "Value": "Chilling Aura"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTNOrbOfCorruption.blp"
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Presence of the Unspeakable - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Decreases the movement speed and attack rate of nearby enemy units. |n|n|cffffcc00Level 1|r - \u003CAOae,DataA1,%\u003E% movement, \u003CAOae,DataB1,%\u003E% attack. |n|cffffcc00Level 2|r - \u003CAOae,DataA2,%\u003E% movement, \u003CAOae,DataB2,%\u003E% attack. |n|cffffcc00Level 3|r - \u003CAOae,DataA3,%\u003E% movement, \u003CAOae,DataB3,%\u003E% attack.|n|cffffcc00Level 4|r - \u003CAOae,DataA4,%\u003E% movement, \u003CAOae,DataB4,%\u003E% attack."
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A0ZJ.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0ZJ.json
@@ -107,11 +107,6 @@
       "Value": "Portal to Nagrand"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTNWarpPortal.blp"
-    },
-    {
       "Id": "arpx",
       "Value": 3
     },
@@ -119,16 +114,6 @@
       "Id": "arhk",
       "Type": 3,
       "Value": "R"
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Slipstream - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Opens a two-way portal to the target location. The portal becomes usable after 5 seconds, and closes 10 seconds after the caster stops channeling.|n|n|cffffcc00Level 1|r - \u003CA00D,Rng1\u003E range. |n|cffffcc00Level 2|r - \u003CA00D,Rng2\u003E range. |n|cffffcc00Level 3|r - \u003CA00D,Rng3\u003E range."
     },
     {
       "Id": "atat",

--- a/mapdata/WarcraftLegacies/AbilityData/A0ZJ.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0ZJ.json
@@ -12,43 +12,7 @@
       "Value": 45
     },
     {
-      "Level": 2,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 45
-    },
-    {
-      "Level": 3,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 45
-    },
-    {
-      "Level": 2,
-      "Id": "amcs",
-      "Value": 250
-    },
-    {
-      "Level": 3,
-      "Id": "amcs",
-      "Value": 350
-    },
-    {
       "Level": 1,
-      "Pointer": 1,
-      "Id": "Ncl1",
-      "Type": 2,
-      "Value": 300
-    },
-    {
-      "Level": 2,
-      "Pointer": 1,
-      "Id": "Ncl1",
-      "Type": 2,
-      "Value": 300
-    },
-    {
-      "Level": 3,
       "Pointer": 1,
       "Id": "Ncl1",
       "Type": 2,
@@ -61,51 +25,13 @@
       "Value": 17
     },
     {
-      "Level": 2,
-      "Pointer": 3,
-      "Id": "Ncl3",
-      "Value": 17
-    },
-    {
-      "Level": 3,
-      "Pointer": 3,
-      "Id": "Ncl3",
-      "Value": 17
-    },
-    {
       "Level": 1,
       "Pointer": 5,
       "Id": "Ncl5",
       "Value": 0
     },
     {
-      "Level": 2,
-      "Pointer": 5,
-      "Id": "Ncl5",
-      "Value": 0
-    },
-    {
-      "Level": 3,
-      "Pointer": 5,
-      "Id": "Ncl5",
-      "Value": 0
-    },
-    {
       "Level": 1,
-      "Pointer": 6,
-      "Id": "Ncl6",
-      "Type": 3,
-      "Value": "corrosivebreath"
-    },
-    {
-      "Level": 2,
-      "Pointer": 6,
-      "Id": "Ncl6",
-      "Type": 3,
-      "Value": "corrosivebreath"
-    },
-    {
-      "Level": 3,
       "Pointer": 6,
       "Id": "Ncl6",
       "Type": 3,
@@ -123,31 +49,7 @@
       "Value": 200
     },
     {
-      "Level": 2,
-      "Id": "aran",
-      "Type": 2,
-      "Value": 6000
-    },
-    {
-      "Level": 3,
-      "Id": "aran",
-      "Type": 2,
-      "Value": 9000
-    },
-    {
       "Level": 1,
-      "Pointer": 2,
-      "Id": "Ncl2",
-      "Value": 2
-    },
-    {
-      "Level": 2,
-      "Pointer": 2,
-      "Id": "Ncl2",
-      "Value": 2
-    },
-    {
-      "Level": 3,
       "Pointer": 2,
       "Id": "Ncl2",
       "Value": 2
@@ -240,34 +142,10 @@
       "Value": "Portal to Nagrand"
     },
     {
-      "Level": 2,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Slipstream - [|cffffcc00Level 2|r]"
-    },
-    {
-      "Level": 3,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Slipstream - [|cffffcc00Level 3|r]"
-    },
-    {
       "Level": 1,
       "Id": "aub1",
       "Type": 3,
       "Value": "Opens a two-way portal to Nagrand at the target location within a range of \u003CA00D,Rng1\u003E. The portal becomes usable after 5 seconds, and closes 10 seconds after the caster stops channeling."
-    },
-    {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Opens a two-way portal to the target location within a range of \u003CA00D,Rng2\u003E. The portal becomes usable after 5 seconds, and closes 20 seconds after the caster stops channeling."
-    },
-    {
-      "Level": 3,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Opens a two-way portal to the target location within a range of \u003CA00D,Rng3\u003E. The portal becomes usable after 5 seconds, and closes 30 seconds after the caster stops channeling."
     }
   ]
 }

--- a/mapdata/WarcraftLegacies/AbilityData/A0ZU.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0ZU.json
@@ -80,11 +80,6 @@
       "Value": "W"
     },
     {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Summons \u003CAOsf,DataB1\u003E Spirit Wolves to fight the Far Seer\u0027s enemies. |nLasts \u003CAOsf,Dur1\u003E seconds. |n|n|cffffcc00Level 1|r - \u003Cosw1,realHP\u003E hit points, \u003Cosw1,mindmg1\u003E - \u003Cosw1,maxdmg1\u003E damage. 2 wolves summoned.|n|cffffcc00Level 2|r - \u003Cosw2,realHP\u003E hit points, \u003Cosw2,mindmg1\u003E - \u003Cosw2,maxdmg1\u003E damage and Critical Strike. 2 wolves summoned.|n|cffffcc00Level 3|r - \u003Cosw3,realHP\u003E hit points, \u003Cosw3,mindmg1\u003E - \u003Cosw3,maxdmg1\u003E damage and Critical Strike. 2 wolves summoned.|n|cffffcc00Level 4|r - \u003Cosw3,realHP\u003E hit points, \u003Cosw3,mindmg1\u003E - \u003Cosw3,maxdmg1\u003E damage, and Critical Strike. 4 wolves summoned.|n|cffffcc00Level 5|r - \u003Cosw3,realHP\u003E hit points, \u003Cosw3,mindmg1\u003E - \u003Cosw3,maxdmg1\u003E damage and Critical Strike. 6 wolves summoned.|n"
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A104.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A104.json
@@ -12,52 +12,6 @@
       "Value": 200
     },
     {
-      "Level": 2,
-      "Id": "aare",
-      "Type": 2,
-      "Value": 200
-    },
-    {
-      "Level": 3,
-      "Id": "aare",
-      "Type": 2,
-      "Value": 200
-    },
-    {
-      "Level": 4,
-      "Id": "aare",
-      "Type": 2,
-      "Value": 200
-    },
-    {
-      "Level": 2,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 25
-    },
-    {
-      "Level": 3,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 15
-    },
-    {
-      "Level": 4,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 5
-    },
-    {
-      "Level": 2,
-      "Id": "amcs",
-      "Value": 135
-    },
-    {
-      "Level": 4,
-      "Id": "amcs",
-      "Value": 155
-    },
-    {
       "Level": 1,
       "Pointer": 1,
       "Id": "Ncl1",
@@ -65,46 +19,7 @@
       "Value": 0.5
     },
     {
-      "Level": 2,
-      "Pointer": 1,
-      "Id": "Ncl1",
-      "Type": 2,
-      "Value": 0.5
-    },
-    {
-      "Level": 3,
-      "Pointer": 1,
-      "Id": "Ncl1",
-      "Type": 2,
-      "Value": 0.5
-    },
-    {
-      "Level": 4,
-      "Pointer": 1,
-      "Id": "Ncl1",
-      "Type": 2,
-      "Value": 0.5
-    },
-    {
       "Level": 1,
-      "Pointer": 2,
-      "Id": "Ncl2",
-      "Value": 2
-    },
-    {
-      "Level": 2,
-      "Pointer": 2,
-      "Id": "Ncl2",
-      "Value": 2
-    },
-    {
-      "Level": 3,
-      "Pointer": 2,
-      "Id": "Ncl2",
-      "Value": 2
-    },
-    {
-      "Level": 4,
       "Pointer": 2,
       "Id": "Ncl2",
       "Value": 2
@@ -116,64 +31,13 @@
       "Value": 19
     },
     {
-      "Level": 3,
-      "Pointer": 3,
-      "Id": "Ncl3",
-      "Value": 19
-    },
-    {
-      "Level": 4,
-      "Pointer": 3,
-      "Id": "Ncl3",
-      "Value": 19
-    },
-    {
       "Level": 1,
       "Pointer": 5,
       "Id": "Ncl5",
       "Value": 0
     },
     {
-      "Level": 2,
-      "Pointer": 5,
-      "Id": "Ncl5",
-      "Value": 0
-    },
-    {
-      "Level": 3,
-      "Pointer": 5,
-      "Id": "Ncl5",
-      "Value": 0
-    },
-    {
-      "Level": 4,
-      "Pointer": 5,
-      "Id": "Ncl5",
-      "Value": 0
-    },
-    {
       "Level": 1,
-      "Pointer": 6,
-      "Id": "Ncl6",
-      "Type": 3,
-      "Value": "flamestrike"
-    },
-    {
-      "Level": 2,
-      "Pointer": 6,
-      "Id": "Ncl6",
-      "Type": 3,
-      "Value": "flamestrike"
-    },
-    {
-      "Level": 3,
-      "Pointer": 6,
-      "Id": "Ncl6",
-      "Type": 3,
-      "Value": "flamestrike"
-    },
-    {
-      "Level": 4,
       "Pointer": 6,
       "Id": "Ncl6",
       "Type": 3,
@@ -185,37 +49,8 @@
       "Value": "other"
     },
     {
-      "Level": 2,
-      "Id": "aran",
-      "Type": 2,
-      "Value": 600
-    },
-    {
-      "Level": 3,
-      "Id": "aran",
-      "Type": 2,
-      "Value": 600
-    },
-    {
-      "Level": 4,
-      "Id": "aran",
-      "Type": 2,
-      "Value": 600
-    },
-    {
       "Id": "alev",
       "Value": 1
-    },
-    {
-      "Level": 3,
-      "Id": "amcs",
-      "Value": 145
-    },
-    {
-      "Level": 2,
-      "Pointer": 3,
-      "Id": "Ncl3",
-      "Value": 19
     },
     {
       "Id": "aher",
@@ -313,46 +148,10 @@
       "Value": "Storm Surge"
     },
     {
-      "Level": 2,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Mass Frost Armor - [|cffffcc00Level 2|r]"
-    },
-    {
-      "Level": 3,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Mass Frost Armor - [|cffffcc00Level 3|r]"
-    },
-    {
-      "Level": 4,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Mass Frost Armor - [|cffffcc00Level 4|r]"
-    },
-    {
       "Level": 1,
       "Id": "aub1",
       "Type": 3,
       "Value": "The Elemental Lord releases a burst of energy at a target location, dealing 50 damage to enemy land units and purging them for 3 seconds. Deals 500 damage to summoned units."
-    },
-    {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Applies Frost Armor to all friendly unit in a target area for \u003CA13S,DataA2\u003E seconds, granting \u003CA13S,DataB2\u003E bonus armour and slowing units that attack them for 2 seconds."
-    },
-    {
-      "Level": 3,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Applies Frost Armor to all friendly unit in a target area for \u003CA13S,DataA3\u003E seconds, granting \u003CA13S,DataB3\u003E bonus armour and slowing units that attack them for 2 seconds."
-    },
-    {
-      "Level": 4,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Applies Frost Armor to all friendly unit in a target area for \u003CA13S,DataA4\u003E seconds, granting \u003CA13S,DataB4\u003E bonus armour and slowing units that attack them for 2 seconds."
     },
     {
       "Id": "abpx",

--- a/mapdata/WarcraftLegacies/AbilityData/A104.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A104.json
@@ -113,11 +113,6 @@
       "Value": "W"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTNMassFrostArmor.blp"
-    },
-    {
       "Id": "arpx",
       "Value": 1
     },
@@ -125,16 +120,6 @@
       "Id": "arhk",
       "Type": 3,
       "Value": "W"
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Mass Frost Armor - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Grants Frost Armor to all friendly unit in a target area for \u003CA13S,DataA1\u003E seconds. |n|n|cffffcc00Level 1|r - Grants \u003CA13S,DataB1\u003E armor and has a \u003CA13R,Cool1\u003E second cooldown.|n|cffffcc00Level 2|r - Grants \u003CA13S,DataB2\u003E armor and has a \u003CA13R,Cool2\u003E second cooldown.|n|cffffcc00Level 3|r - Grants \u003CA13S,DataB3\u003E armor and has a \u003CA13R,Cool3\u003E second cooldown.|n|cffffcc00Level 4|r - Grants \u003CA13S,DataB4\u003E armor and has a \u003CA13R,Cool4\u003E second cooldown."
     },
     {
       "Id": "atat",

--- a/mapdata/WarcraftLegacies/AbilityData/A108.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A108.json
@@ -113,16 +113,6 @@
       "Value": "Q"
     },
     {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Healing Spray (|cffffcc00Q|r)  - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Rexxar sprays waves of mists into his allies healing them. |n|n|cffffcc00Level 1|r - 3 waves at 60 hit points healed each. |n|cffffcc00Level 2|r - 4 waves at 65 hit points healed each. |n|cffffcc00Level 3|r - 5 waves at 75 hit points healed each.|n|cffffcc00Level 4|r - 6 waves at 85 hit points healed each.|n|cffffcc00Level 5|r - 7 waves at 100 hit points healed each."
-    },
-    {
       "Id": "asat",
       "Type": 3,
       "Value": "war3mapImported\\LowQualityCannonball.mdx"

--- a/mapdata/WarcraftLegacies/AbilityData/A10A.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A10A.json
@@ -21,12 +21,6 @@
       "Value": "Causes the caster to generate an magical Glaive whenever they cast a spell. The orb orbits around the caster for 20 seconds, dealing 50 damage to enemy units it strikes."
     },
     {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Increases the rate at which this unit gathers lumber."
-    },
-    {
       "Id": "aart",
       "Type": 3,
       "Value": "ReplaceableTextures\\PassiveButtons\\PASGlaiveStorm.BLP"

--- a/mapdata/WarcraftLegacies/AbilityData/A10C.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A10C.json
@@ -12,61 +12,12 @@
       "Value": 45
     },
     {
-      "Level": 2,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 60
-    },
-    {
-      "Level": 3,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 60
-    },
-    {
-      "Level": 4,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 60
-    },
-    {
       "Level": 1,
       "Id": "amcs",
       "Value": 60
     },
     {
-      "Level": 2,
-      "Id": "amcs",
-      "Value": 135
-    },
-    {
-      "Level": 4,
-      "Id": "amcs",
-      "Value": 155
-    },
-    {
       "Level": 1,
-      "Pointer": 1,
-      "Id": "Ncl1",
-      "Type": 2,
-      "Value": 0.5
-    },
-    {
-      "Level": 2,
-      "Pointer": 1,
-      "Id": "Ncl1",
-      "Type": 2,
-      "Value": 0.5
-    },
-    {
-      "Level": 3,
-      "Pointer": 1,
-      "Id": "Ncl1",
-      "Type": 2,
-      "Value": 0.5
-    },
-    {
-      "Level": 4,
       "Pointer": 1,
       "Id": "Ncl1",
       "Type": 2,
@@ -79,37 +30,7 @@
       "Value": 17
     },
     {
-      "Level": 3,
-      "Pointer": 3,
-      "Id": "Ncl3",
-      "Value": 17
-    },
-    {
-      "Level": 4,
-      "Pointer": 3,
-      "Id": "Ncl3",
-      "Value": 17
-    },
-    {
       "Level": 1,
-      "Pointer": 5,
-      "Id": "Ncl5",
-      "Value": 0
-    },
-    {
-      "Level": 2,
-      "Pointer": 5,
-      "Id": "Ncl5",
-      "Value": 0
-    },
-    {
-      "Level": 3,
-      "Pointer": 5,
-      "Id": "Ncl5",
-      "Value": 0
-    },
-    {
-      "Level": 4,
       "Pointer": 5,
       "Id": "Ncl5",
       "Value": 0
@@ -122,27 +43,6 @@
       "Value": "darkconversion"
     },
     {
-      "Level": 2,
-      "Pointer": 6,
-      "Id": "Ncl6",
-      "Type": 3,
-      "Value": "howlofterror"
-    },
-    {
-      "Level": 3,
-      "Pointer": 6,
-      "Id": "Ncl6",
-      "Type": 3,
-      "Value": "howlofterror"
-    },
-    {
-      "Level": 4,
-      "Pointer": 6,
-      "Id": "Ncl6",
-      "Type": 3,
-      "Value": "howlofterror"
-    },
-    {
       "Id": "arac",
       "Type": 3,
       "Value": "undead"
@@ -150,17 +50,6 @@
     {
       "Id": "alev",
       "Value": 1
-    },
-    {
-      "Level": 3,
-      "Id": "amcs",
-      "Value": 145
-    },
-    {
-      "Level": 2,
-      "Pointer": 3,
-      "Id": "Ncl3",
-      "Value": 17
     },
     {
       "Id": "aher",
@@ -247,46 +136,10 @@
       "Value": "Death Pact"
     },
     {
-      "Level": 2,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Reap - [|cffffcc00Level 2|r]"
-    },
-    {
-      "Level": 3,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Reap - [|cffffcc00Level 3|r]"
-    },
-    {
-      "Level": 4,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Reap - [|cffffcc00Level 4|r]"
-    },
-    {
       "Level": 1,
       "Id": "aub1",
       "Type": 3,
       "Value": "Sacrifices a friendly Undead unit, giving 150% of its hit points to the Death Knight and 20% of it\u0027s hit points in mana. Prioritises summoned units."
-    },
-    {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Instantly kills the 5 lowest level non-Hero nearby enemy units, granting the caster 5 Strength for each unit slain for 30 seconds."
-    },
-    {
-      "Level": 3,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Instantly kills the 7 lowest level non-Hero nearby enemy units, granting the caster 5 Strength for each unit slain for 30 seconds."
-    },
-    {
-      "Level": 4,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Instantly kills the 9 lowest level non-Hero nearby enemy units, granting the caster 5 Strength for each unit slain for 30 seconds."
     }
   ]
 }

--- a/mapdata/WarcraftLegacies/AbilityData/A10C.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A10C.json
@@ -101,11 +101,6 @@
       "Value": "Death Pact"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTNCursedScythe.blp"
-    },
-    {
       "Id": "arpx",
       "Value": 1
     },
@@ -113,16 +108,6 @@
       "Id": "arhk",
       "Type": 3,
       "Value": "W"
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Reap - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Instantly kills the lowest level nearby non-Hero enemy units, granting the caster 5 Strength for each unit slain for 30 seconds. |n|n|cffffcc00Level 1|r - Kills 3 units.|n|cffffcc00Level 2|r - Kills 5 units.|n|cffffcc00Level 3|r - Kills 7 units.|n|cffffcc00Level 4|r - Kills 9 units."
     },
     {
       "Id": "atat",

--- a/mapdata/WarcraftLegacies/AbilityData/A10K.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A10K.json
@@ -13,27 +13,6 @@
       "Value": 0
     },
     {
-      "Level": 2,
-      "Pointer": 1,
-      "Id": "Eev1",
-      "Type": 2,
-      "Value": 0
-    },
-    {
-      "Level": 3,
-      "Pointer": 1,
-      "Id": "Eev1",
-      "Type": 2,
-      "Value": 0
-    },
-    {
-      "Level": 4,
-      "Pointer": 1,
-      "Id": "Eev1",
-      "Type": 2,
-      "Value": 0
-    },
-    {
       "Id": "alev",
       "Value": 1
     },
@@ -83,46 +62,10 @@
       "Value": "Hideous Appendages"
     },
     {
-      "Level": 2,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Hideous Appendages - [|cffffcc00Level 2|r]"
-    },
-    {
-      "Level": 3,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Hideous Appendages - [|cffffcc00Level 3|r]"
-    },
-    {
-      "Level": 4,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Hideous Appendages - [|cffffcc00Level 4|r]"
-    },
-    {
       "Level": 1,
       "Id": "aub1",
       "Type": 3,
       "Value": "This unit is surrounded by Tentacles which attack nearby enemy units."
-    },
-    {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "N\u0027zoth has 6 Tentacles which attack nearby enemy units autonomously. Each Tentacle has the same attack damage as N\u0027zoth."
-    },
-    {
-      "Level": 3,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "N\u0027zoth has 7 Tentacles which attack nearby enemy units autonomously. Each Tentacle has the same attack damage as N\u0027zoth."
-    },
-    {
-      "Level": 4,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "N\u0027zoth has 8 Tentacles which attack nearby enemy units autonomously. Each Tentacle has the same attack damage as N\u0027zoth."
     },
     {
       "Id": "abpy",

--- a/mapdata/WarcraftLegacies/AbilityData/A10K.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A10K.json
@@ -41,21 +41,6 @@
       "Value": "Hideous Appendages"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTNTentacles.blp"
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "[|cffffcc00E|r] Learn Hideous Appendages - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "N\u0027zoth has numerous Tentacles which attack nearby enemy units autonomously. Each Tentacle has the same attack damage as N\u0027zoth. |n|n|cffffcc00Level 1|r - 5 Tentacles. |n|cffffcc00Level 2|r - 6 Tentacles. |n|cffffcc00Level 3|r - 7 Tentacles. |n|cffffcc00Level 3|r - 8 Tentacles."
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A10O.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A10O.json
@@ -201,16 +201,6 @@
       "Value": "Q"
     },
     {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Greater Storm Bolt (|cffffcc00Q|r) - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "A magical hammer that is thrown at an enemy unit, causing damage and stunning the target. |n|n|cffffcc00Level 1|r - 250 damage, 4 second stun. 2 second on Heroes.|n|cffffcc00Level 2|r - 300 damage, 5 second stun. 2.5 seconds on Heroes.|n|cffffcc00Level 3|r - 350 damage, 6 second stun. 3 seconds on Heroes.|n|cffffcc00Level 4|r - 400 damage, 7 second stun. 3.5 seconds on Heroes"
-    },
-    {
       "Level": 2,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A111.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A111.json
@@ -62,11 +62,6 @@
       "Value": "Light of the Goddess"
     },
     {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "|cff7777aaHoly Light|r |cff7777aa[E]|r"
-    },
-    {
       "Id": "atat",
       "Type": 3,
       "Value": "Holy Light Royal.mdx"

--- a/mapdata/WarcraftLegacies/AbilityData/A11K.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A11K.json
@@ -234,19 +234,9 @@
       "Value": "Turns all friendly units invulnerable in an area around Aegwynn. |nLasts 4 seconds."
     },
     {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Time\u0027s Shield"
-    },
-    {
       "Id": "anam",
       "Type": 3,
       "Value": "Time\u0027s Shield"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Turns all friendly units invulnerable in an area around Aegwynn. |nLasts 1/2/3/4 seconds. |n|cffffcc00Level 1|r - 1 second duration. |n|cffffcc00Level 2|r - 2 seconds duration. |n|cffffcc00Level 3|r - 3 seconds duration.|n|cffffcc00Level 4|r - 4 seconds duration."
     },
     {
       "Id": "aeat",
@@ -269,11 +259,6 @@
     },
     {
       "Id": "aart",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTN_LunarShield.blp"
-    },
-    {
-      "Id": "arar",
       "Type": 3,
       "Value": "ReplaceableTextures\\CommandButtons\\BTN_LunarShield.blp"
     }

--- a/mapdata/WarcraftLegacies/AbilityData/A11N.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A11N.json
@@ -38,11 +38,6 @@
       "Value": "E"
     },
     {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "When this hero deals damage, it will regain a portion of the damage dealt as mana. |n|n|cffffcc00Level 1|r - 40% of the damage gained as mana. |n|cffffcc00Level 2|r - 60% of the damage gained as mana.|n|cffffcc00Level 3|r - 80% of the damage gained as mana.|n|cffffcc00Level 4|r - 100% of the damage gained as mana."
-    },
-    {
       "Level": 1,
       "Id": "aub1",
       "Type": 3,
@@ -54,19 +49,9 @@
       "Value": "Arcane Absorption"
     },
     {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Arcane Absorption - [|cffffcc00Level %d|r]"
-    },
-    {
       "Id": "aart",
       "Type": 3,
       "Value": "ReplaceableTextures/PassiveButtons/PASArcaneEnergy.blp"
-    },
-    {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures/CommandButtons/BTNArcaneEnergy.blp"
     },
     {
       "Level": 1,

--- a/mapdata/WarcraftLegacies/AbilityData/A11N.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A11N.json
@@ -6,48 +6,6 @@
   ],
   "Modifications": [
     {
-      "Level": 2,
-      "Pointer": 1,
-      "Id": "Ocr1",
-      "Type": 2,
-      "Value": 0
-    },
-    {
-      "Level": 3,
-      "Pointer": 1,
-      "Id": "Ocr1",
-      "Type": 2,
-      "Value": 0
-    },
-    {
-      "Level": 4,
-      "Pointer": 1,
-      "Id": "Ocr1",
-      "Type": 2,
-      "Value": 0
-    },
-    {
-      "Level": 2,
-      "Pointer": 2,
-      "Id": "Ocr2",
-      "Type": 2,
-      "Value": 0
-    },
-    {
-      "Level": 3,
-      "Pointer": 2,
-      "Id": "Ocr2",
-      "Type": 2,
-      "Value": 0
-    },
-    {
-      "Level": 4,
-      "Pointer": 2,
-      "Id": "Ocr2",
-      "Type": 2,
-      "Value": 0
-    },
-    {
       "Id": "alev",
       "Value": 1
     },
@@ -85,34 +43,10 @@
       "Value": "When this hero deals damage, it will regain a portion of the damage dealt as mana. |n|n|cffffcc00Level 1|r - 40% of the damage gained as mana. |n|cffffcc00Level 2|r - 60% of the damage gained as mana.|n|cffffcc00Level 3|r - 80% of the damage gained as mana.|n|cffffcc00Level 4|r - 100% of the damage gained as mana."
     },
     {
-      "Level": 4,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Arcane Absorption - [|cffffcc00Level 4|r]"
-    },
-    {
       "Level": 1,
       "Id": "aub1",
       "Type": 3,
       "Value": "When this unit deals damage, 40% of the damage will be gained as mana."
-    },
-    {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "When this hero deals damage, 60% of the damage will be gained as mana"
-    },
-    {
-      "Level": 3,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "When this hero deals damage, 80% of the damage will be gained as mana"
-    },
-    {
-      "Level": 4,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "When this hero deals damage, 100% of the damage will be gained as mana"
     },
     {
       "Id": "anam",
@@ -139,18 +73,6 @@
       "Id": "atp1",
       "Type": 3,
       "Value": "Arcane Absorption"
-    },
-    {
-      "Level": 2,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Arcane Absorption - [|cffffcc00Level 2|r]"
-    },
-    {
-      "Level": 3,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Arcane Absorption - [|cffffcc00Level 3|r]"
     },
     {
       "Id": "abpx",

--- a/mapdata/WarcraftLegacies/AbilityData/A11R.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A11R.json
@@ -70,23 +70,8 @@
       "Value": "Unspoiled Wilderness"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": ""
-    },
-    {
       "Id": "arpx",
       "Value": 0
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": ""
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": ""
     },
     {
       "Id": "atat",

--- a/mapdata/WarcraftLegacies/AbilityData/A12D.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A12D.json
@@ -68,24 +68,6 @@
       "Value": 6
     },
     {
-      "Level": 4,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 0
-    },
-    {
-      "Level": 4,
-      "Id": "ahdu",
-      "Type": 2,
-      "Value": 4
-    },
-    {
-      "Level": 4,
-      "Id": "adur",
-      "Type": 2,
-      "Value": 4
-    },
-    {
       "Level": 1,
       "Id": "atar",
       "Type": 3,
@@ -99,12 +81,6 @@
     },
     {
       "Level": 3,
-      "Id": "atar",
-      "Type": 3,
-      "Value": "air,friend,ground,invulnerable,organic,self,vulnerable"
-    },
-    {
-      "Level": 4,
       "Id": "atar",
       "Type": 3,
       "Value": "air,friend,ground,invulnerable,organic,self,vulnerable"
@@ -133,12 +109,6 @@
       "Value": "B0B6,BOvc"
     },
     {
-      "Level": 4,
-      "Id": "abuf",
-      "Type": 3,
-      "Value": "B0B1,BOvc"
-    },
-    {
       "Level": 1,
       "Id": "amcs",
       "Value": 0
@@ -150,11 +120,6 @@
     },
     {
       "Level": 3,
-      "Id": "amcs",
-      "Value": 0
-    },
-    {
-      "Level": 4,
       "Id": "amcs",
       "Value": 0
     },
@@ -222,12 +187,6 @@
       "Value": 2
     },
     {
-      "Level": 4,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Time\u0027s Shield - [|cffffcc00Level 4|r]"
-    },
-    {
       "Level": 1,
       "Id": "aub1",
       "Type": 3,
@@ -244,12 +203,6 @@
       "Id": "aub1",
       "Type": 3,
       "Value": "Turns all friendly units invulnerable in an area around Aegwynn. |nLasts 3 seconds."
-    },
-    {
-      "Level": 4,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Turns all friendly units invulnerable in an area around Aegwynn. |nLasts 4 seconds."
     },
     {
       "Id": "aret",

--- a/mapdata/WarcraftLegacies/AbilityData/A12D.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A12D.json
@@ -205,19 +205,9 @@
       "Value": "Turns all friendly units invulnerable in an area around Aegwynn. |nLasts 3 seconds."
     },
     {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Time\u0027s Shield"
-    },
-    {
       "Id": "anam",
       "Type": 3,
       "Value": "Legendary Warrior"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Turns all friendly units invulnerable in an area around Aegwynn. |nLasts 1/2/3/4 seconds. |n|cffffcc00Level 1|r - 1 second duration. |n|cffffcc00Level 2|r - 2 seconds duration. |n|cffffcc00Level 3|r - 3 seconds duration.|n|cffffcc00Level 4|r - 4 seconds duration."
     },
     {
       "Id": "aeat",
@@ -240,11 +230,6 @@
     },
     {
       "Id": "aart",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTN_LunarShield.blp"
-    },
-    {
-      "Id": "arar",
       "Type": 3,
       "Value": "ReplaceableTextures\\CommandButtons\\BTN_LunarShield.blp"
     }

--- a/mapdata/WarcraftLegacies/AbilityData/A12Q.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A12Q.json
@@ -36,11 +36,6 @@
       "Value": "D"
     },
     {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Mana Shield"
-    },
-    {
       "Id": "abpx",
       "Value": 1
     },
@@ -65,11 +60,6 @@
       "Id": "auhk",
       "Type": 3,
       "Value": "D"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Creates a shield that absorbs damage by using the hero\u0027s mana. |n|n|cffffcc00Level 1|r - \u003CANms,DataA1\u003E damage per point of mana. |n|cffffcc00Level 2|r - \u003CANms,DataA2\u003E damage per point of mana. |n|cffffcc00Level 3|r - \u003CANms,DataA3\u003E damage per point of mana. |n|cffffcc00Level 3|r - \u003CANms,DataA4\u003E damage per point of mana."
     },
     {
       "Level": 1,

--- a/mapdata/WarcraftLegacies/AbilityData/A12Q.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A12Q.json
@@ -6,27 +6,6 @@
   ],
   "Modifications": [
     {
-      "Level": 2,
-      "Pointer": 1,
-      "Id": "Nms1",
-      "Type": 2,
-      "Value": 4
-    },
-    {
-      "Level": 3,
-      "Pointer": 1,
-      "Id": "Nms1",
-      "Type": 2,
-      "Value": 6
-    },
-    {
-      "Level": 4,
-      "Pointer": 1,
-      "Id": "Nms1",
-      "Type": 2,
-      "Value": 8
-    },
-    {
       "Id": "arac",
       "Type": 3,
       "Value": "human"
@@ -55,18 +34,6 @@
       "Id": "arhk",
       "Type": 3,
       "Value": "D"
-    },
-    {
-      "Level": 4,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Activate Mana Shield - [|cffffcc00Level 4|r]"
-    },
-    {
-      "Level": 4,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Activates a shield that absorbs \u003CANms,DataA4\u003E damage per point of mana."
     },
     {
       "Id": "aret",
@@ -103,24 +70,6 @@
       "Id": "arut",
       "Type": 3,
       "Value": "Creates a shield that absorbs damage by using the hero\u0027s mana. |n|n|cffffcc00Level 1|r - \u003CANms,DataA1\u003E damage per point of mana. |n|cffffcc00Level 2|r - \u003CANms,DataA2\u003E damage per point of mana. |n|cffffcc00Level 3|r - \u003CANms,DataA3\u003E damage per point of mana. |n|cffffcc00Level 3|r - \u003CANms,DataA4\u003E damage per point of mana."
-    },
-    {
-      "Level": 2,
-      "Id": "aut1",
-      "Type": 3,
-      "Value": "Deactivate Mana Shield"
-    },
-    {
-      "Level": 3,
-      "Id": "aut1",
-      "Type": 3,
-      "Value": "Deactivate Mana Shield"
-    },
-    {
-      "Level": 4,
-      "Id": "aut1",
-      "Type": 3,
-      "Value": "Deactivate Mana Shield"
     },
     {
       "Level": 1,

--- a/mapdata/WarcraftLegacies/AbilityData/A12V.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A12V.json
@@ -6,67 +6,19 @@
   ],
   "Modifications": [
     {
-      "Level": 2,
-      "Id": "aare",
-      "Type": 2,
-      "Value": 900
-    },
-    {
-      "Level": 3,
-      "Id": "aare",
-      "Type": 2,
-      "Value": 900
-    },
-    {
       "Level": 1,
       "Id": "abuf",
       "Type": 3,
       "Value": "B0B9"
     },
     {
-      "Level": 2,
-      "Id": "abuf",
-      "Type": 3,
-      "Value": "B06L"
-    },
-    {
-      "Level": 3,
-      "Id": "abuf",
-      "Type": 3,
-      "Value": "B06L"
-    },
-    {
       "Level": 1,
       "Id": "acas",
       "Type": 2,
       "Value": 1
     },
     {
-      "Level": 2,
-      "Id": "acas",
-      "Type": 2,
-      "Value": 1
-    },
-    {
-      "Level": 3,
-      "Id": "acas",
-      "Type": 2,
-      "Value": 1
-    },
-    {
       "Level": 1,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 120
-    },
-    {
-      "Level": 2,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 120
-    },
-    {
-      "Level": 3,
       "Id": "acdn",
       "Type": 2,
       "Value": 120
@@ -77,16 +29,6 @@
       "Value": 150
     },
     {
-      "Level": 2,
-      "Id": "amcs",
-      "Value": 200
-    },
-    {
-      "Level": 3,
-      "Id": "amcs",
-      "Value": 250
-    },
-    {
       "Level": 1,
       "Pointer": 1,
       "Id": "Hfs1",
@@ -94,35 +36,7 @@
       "Value": 0
     },
     {
-      "Level": 2,
-      "Pointer": 1,
-      "Id": "Hfs1",
-      "Type": 2,
-      "Value": -40
-    },
-    {
-      "Level": 3,
-      "Pointer": 1,
-      "Id": "Hfs1",
-      "Type": 2,
-      "Value": -50
-    },
-    {
       "Level": 1,
-      "Pointer": 2,
-      "Id": "Hfs2",
-      "Type": 2,
-      "Value": 1
-    },
-    {
-      "Level": 2,
-      "Pointer": 2,
-      "Id": "Hfs2",
-      "Type": 2,
-      "Value": 1
-    },
-    {
-      "Level": 3,
       "Pointer": 2,
       "Id": "Hfs2",
       "Type": 2,
@@ -136,35 +50,7 @@
       "Value": 0
     },
     {
-      "Level": 2,
-      "Pointer": 3,
-      "Id": "Hfs3",
-      "Type": 2,
-      "Value": -15
-    },
-    {
-      "Level": 3,
-      "Pointer": 3,
-      "Id": "Hfs3",
-      "Type": 2,
-      "Value": -20
-    },
-    {
       "Level": 1,
-      "Pointer": 5,
-      "Id": "Hfs5",
-      "Type": 2,
-      "Value": 1
-    },
-    {
-      "Level": 2,
-      "Pointer": 5,
-      "Id": "Hfs5",
-      "Type": 2,
-      "Value": 1
-    },
-    {
-      "Level": 3,
       "Pointer": 5,
       "Id": "Hfs5",
       "Type": 2,
@@ -178,33 +64,7 @@
       "Value": 0
     },
     {
-      "Level": 2,
-      "Pointer": 6,
-      "Id": "Hfs6",
-      "Type": 2,
-      "Value": 900
-    },
-    {
-      "Level": 3,
-      "Pointer": 6,
-      "Id": "Hfs6",
-      "Type": 2,
-      "Value": 900
-    },
-    {
       "Level": 1,
-      "Id": "adur",
-      "Type": 2,
-      "Value": 35
-    },
-    {
-      "Level": 2,
-      "Id": "adur",
-      "Type": 2,
-      "Value": 35
-    },
-    {
-      "Level": 3,
       "Id": "adur",
       "Type": 2,
       "Value": 35
@@ -216,31 +76,7 @@
       "Value": ""
     },
     {
-      "Level": 2,
-      "Id": "aeff",
-      "Type": 3,
-      "Value": "X00F"
-    },
-    {
-      "Level": 3,
-      "Id": "aeff",
-      "Type": 3,
-      "Value": "X00F"
-    },
-    {
       "Level": 1,
-      "Id": "ahdu",
-      "Type": 2,
-      "Value": 5
-    },
-    {
-      "Level": 2,
-      "Id": "ahdu",
-      "Type": 2,
-      "Value": 5
-    },
-    {
-      "Level": 3,
       "Id": "ahdu",
       "Type": 2,
       "Value": 5
@@ -265,31 +101,7 @@
       "Value": 500
     },
     {
-      "Level": 2,
-      "Id": "aran",
-      "Type": 2,
-      "Value": 650
-    },
-    {
-      "Level": 3,
-      "Id": "aran",
-      "Type": 2,
-      "Value": 650
-    },
-    {
       "Level": 1,
-      "Id": "atar",
-      "Type": 3,
-      "Value": "friend,ground,neutral,self"
-    },
-    {
-      "Level": 2,
-      "Id": "atar",
-      "Type": 3,
-      "Value": "friend,ground,neutral,self"
-    },
-    {
-      "Level": 3,
       "Id": "atar",
       "Type": 3,
       "Value": "friend,ground,neutral,self"
@@ -362,34 +174,10 @@
       "Value": "Blessed Ground"
     },
     {
-      "Level": 2,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Field of Blood - [|cffffcc00Level 2|r]"
-    },
-    {
-      "Level": 3,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Field of Blood - [|cffffcc00Level 3|r]"
-    },
-    {
       "Level": 1,
       "Id": "aub1",
       "Type": 3,
       "Value": "Conjures a Blessed Circle which Heals allied ground units in a target area. |n|nHeals each unit for 150 hit points, then 10 hit points a second for 35 seconds."
-    },
-    {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Conjures a Field of Blood which Heals allied ground units in a target area over time. |n|nHeals 200 hit points over 5 seconds, then 15 hit point every 1 seconds for 35 seconds.|n"
-    },
-    {
-      "Level": 3,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Conjures a Field of Blood which Heals allied ground units in a target area over time. |n|cffffcc00|n|rHeals 250 hit points over 5 seconds, then 20 hit point every 1 seconds for 35 seconds."
     },
     {
       "Id": "aeat",

--- a/mapdata/WarcraftLegacies/AbilityData/A12V.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A12V.json
@@ -139,11 +139,6 @@
       "Value": "Blessed Ground"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTN_CR_BLOOD.blp"
-    },
-    {
       "Id": "arpx",
       "Value": 1
     },
@@ -151,16 +146,6 @@
       "Id": "arhk",
       "Type": 3,
       "Value": "R"
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Field of Blood - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Conjures a field of churning blood which heals allied ground units in a target area over time. |n|n|cffffcc00Level 1|r - Heals 150 hit points over 5 seconds, then 10 hit point every 1 seconds for 35 seconds.|n|cffffcc00Level 2|r - Heals 200 hit points over 5 seconds, then 15 hit point every 1 seconds for 35 seconds.|n|cffffcc00Level 3|r - Heals 250 hit points over 5 seconds, then 20 hit point every 1 seconds for 35 seconds.|n"
     },
     {
       "Id": "asat",

--- a/mapdata/WarcraftLegacies/AbilityData/A133.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A133.json
@@ -43,11 +43,6 @@
       "Value": "W"
     },
     {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Summons \u003CAOsf,DataB1\u003E Spirit Wolves to fight the Far Seer\u0027s enemies. |nLasts \u003CAOsf,Dur1\u003E seconds. |n|n|cffffcc00Level 1|r - \u003Cosw1,realHP\u003E hit points, \u003Cosw1,mindmg1\u003E - \u003Cosw1,maxdmg1\u003E damage and Critical Strike. 2 wolves summoned.|n|cffffcc00Level 2|r - \u003Cosw2,realHP\u003E hit points, \u003Cosw2,mindmg1\u003E - \u003Cosw2,maxdmg1\u003E damage and Critical Strike. 2 wolves summoned.|n|cffffcc00Level 3|r - \u003Cosw3,realHP\u003E hit points, \u003Cosw3,mindmg1\u003E - \u003Cosw3,maxdmg1\u003E damage and Critical Strike. 2 wolves summoned.|n|cffffcc00Level 4|r - \u003Cosw3,realHP\u003E hit points, \u003Cosw3,mindmg1\u003E - \u003Cosw3,maxdmg1\u003E damage, and Critical Strike. 4 wolves summoned.|n|cffffcc00Level 5|r - \u003Cosw3,realHP\u003E hit points, \u003Cosw3,mindmg1\u003E - \u003Cosw3,maxdmg1\u003E damage and Critical Strike. 6 wolves summoned.|n"
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A137.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A137.json
@@ -44,11 +44,6 @@
       "Value": "King of Lordaeron sword"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTNFrostMourne.blp"
-    },
-    {
       "Id": "arpx",
       "Value": 0
     },
@@ -56,16 +51,6 @@
       "Id": "arhk",
       "Type": 3,
       "Value": "T"
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn |cffffcc00T|rhe Power of Frostmourne - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Frostmourne gives the power for Arthas to hit multiple enemies with one swing of his sword .|n|n|cffffcc00Level 1|r - 25% of damage is splash. |n|cffffcc00Level 2|r - 40% of damage is splash. |n|cffffcc00Level 3|r - 55% of damage is splash."
     },
     {
       "Level": 1,

--- a/mapdata/WarcraftLegacies/AbilityData/A13E.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A13E.json
@@ -64,11 +64,6 @@
       "Value": "E"
     },
     {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "The Crypt Lord progenerates Carrion Beetle from a target corpse to attack the Crypt Lord\u0027s enemies. Beetles are permanent. |n|n|cffffcc00Level 1|r - Spawns a level 1 Carrion Beetle. Max 6 Beetles. |n|cffffcc00Level 2|r - Spawns a level 2 Carrion Beetle. Max 6 Beetles. |n|cffffcc00Level 3|r - Spawns a level 3 Dire Carrion Beetle. Max 6 Beetles. |n|cffffcc00Level 4|r - Spawns a level 3 Dire Carrion Beetle. Max 12 Beetles."
-    },
-    {
       "Level": 1,
       "Id": "aub1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A13E.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A13E.json
@@ -6,22 +6,6 @@
   ],
   "Modifications": [
     {
-      "Level": 2,
-      "Id": "amcs",
-      "Value": 40
-    },
-    {
-      "Level": 4,
-      "Id": "amcs",
-      "Value": 60
-    },
-    {
-      "Level": 4,
-      "Pointer": 5,
-      "Id": "Ucb5",
-      "Value": 12
-    },
-    {
       "Id": "alev",
       "Value": 1
     },
@@ -85,34 +69,10 @@
       "Value": "The Crypt Lord progenerates Carrion Beetle from a target corpse to attack the Crypt Lord\u0027s enemies. Beetles are permanent. |n|n|cffffcc00Level 1|r - Spawns a level 1 Carrion Beetle. Max 6 Beetles. |n|cffffcc00Level 2|r - Spawns a level 2 Carrion Beetle. Max 6 Beetles. |n|cffffcc00Level 3|r - Spawns a level 3 Dire Carrion Beetle. Max 6 Beetles. |n|cffffcc00Level 4|r - Spawns a level 3 Dire Carrion Beetle. Max 12 Beetles."
     },
     {
-      "Level": 4,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Carrion Beetles - [|cffffcc00Level 4|r]"
-    },
-    {
       "Level": 1,
       "Id": "aub1",
       "Type": 3,
       "Value": "The Druid summons 2 spiders from nearby. The spiders are untargetable and uncontrollable and will attack enemies in proximity."
-    },
-    {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "The Crypt Lord progenerates Carrion Beetle from a target corpse to attack the Crypt Lord\u0027s enemies. Beetles are permanent. |n|n| Spawns a level 2 Carrion Beetle. Max 6 Beetles. |n|n| Got Spiked Carapace, Acid Attack -7 and Burrow."
-    },
-    {
-      "Level": 3,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "The Crypt Lord progenerates Carrion Beetle from a target corpse to attack the Crypt Lord\u0027s enemies. Beetles are permanent. |n|n| Spawns a level 3 Dire Carrion Beetle. Max 6 Beetles. |n|n| Got Spiked Carapace, Acid Attack -10, Burrow and Spawn Beetles."
-    },
-    {
-      "Level": 4,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "The Crypt Lord progenerates Carrion Beetle from a target corpse to attack the Crypt Lord\u0027s enemies. Beetles are permanent. |n|nSpawns a level 3 Dire Carrion Beetle. Max 12 Beetles. |n|nGot Spiked Carapace, Acid Attack -10, Burrow and Spawn Beetles."
     },
     {
       "Id": "anam",

--- a/mapdata/WarcraftLegacies/AbilityData/A13L.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A13L.json
@@ -6,13 +6,6 @@
   ],
   "Modifications": [
     {
-      "Level": 3,
-      "Pointer": 1,
-      "Id": "Ocr1",
-      "Type": 2,
-      "Value": 15
-    },
-    {
       "Level": 1,
       "Pointer": 2,
       "Id": "Ocr2",
@@ -20,35 +13,7 @@
       "Value": 1.5
     },
     {
-      "Level": 2,
-      "Pointer": 2,
-      "Id": "Ocr2",
-      "Type": 2,
-      "Value": 1.5
-    },
-    {
-      "Level": 3,
-      "Pointer": 2,
-      "Id": "Ocr2",
-      "Type": 2,
-      "Value": 1.5
-    },
-    {
       "Level": 1,
-      "Pointer": 4,
-      "Id": "Ocr4",
-      "Type": 2,
-      "Value": 0.1
-    },
-    {
-      "Level": 2,
-      "Pointer": 4,
-      "Id": "Ocr4",
-      "Type": 2,
-      "Value": 0.15
-    },
-    {
-      "Level": 3,
       "Pointer": 4,
       "Id": "Ocr4",
       "Type": 2,
@@ -93,34 +58,10 @@
       "Value": "Veteran\u0027s Insight"
     },
     {
-      "Level": 2,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Combat Experience"
-    },
-    {
-      "Level": 3,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Combat Experience"
-    },
-    {
       "Level": 1,
       "Id": "aub1",
       "Type": 3,
       "Value": "Gives a 15% chance to dodge an attack and a 15% chance to deal 1.5x normal damage."
-    },
-    {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Gives a 15% chance to dodge an attack and a 10% chance to deal 1.5x normal damage."
-    },
-    {
-      "Level": 3,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Gives a 10% chance to dodge an attack and a 15% chance to deal 1.5x normal damage."
     }
   ]
 }

--- a/mapdata/WarcraftLegacies/AbilityData/A13L.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A13L.json
@@ -47,11 +47,6 @@
       "Value": "Veteran\u0027s Insight"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTNHeadHunterBerserker.blp"
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A13O.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A13O.json
@@ -98,11 +98,6 @@
       "Value": "W"
     },
     {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Summons \u003CAOsf,DataB1\u003E Spirit Wolves to fight the Far Seer\u0027s enemies. |nLasts \u003CAOsf,Dur1\u003E seconds. |n|n|cffffcc00Level 1|r - \u003Cosw1,realHP\u003E hit points, \u003Cosw1,mindmg1\u003E - \u003Cosw1,maxdmg1\u003E damage. 2 wolves summoned.|n|cffffcc00Level 2|r - \u003Cosw2,realHP\u003E hit points, \u003Cosw2,mindmg1\u003E - \u003Cosw2,maxdmg1\u003E damage and Critical Strike. 2 wolves summoned.|n|cffffcc00Level 3|r - \u003Cosw3,realHP\u003E hit points, \u003Cosw3,mindmg1\u003E - \u003Cosw3,maxdmg1\u003E damage and Critical Strike. 2 wolves summoned.|n|cffffcc00Level 4|r - \u003Cosw3,realHP\u003E hit points, \u003Cosw3,mindmg1\u003E - \u003Cosw3,maxdmg1\u003E damage, and Critical Strike. 4 wolves summoned.|n|cffffcc00Level 5|r - \u003Cosw3,realHP\u003E hit points, \u003Cosw3,mindmg1\u003E - \u003Cosw3,maxdmg1\u003E damage and Critical Strike. 6 wolves summoned.|n"
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/A13Q.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A13Q.json
@@ -13,74 +13,11 @@
       "Value": 20
     },
     {
-      "Level": 3,
-      "Pointer": 1,
-      "Id": "War1",
-      "Type": 2,
-      "Value": 30
-    },
-    {
-      "Level": 4,
-      "Pointer": 1,
-      "Id": "War1",
-      "Type": 2,
-      "Value": 35
-    },
-    {
       "Level": 1,
       "Pointer": 2,
       "Id": "War2",
       "Type": 2,
       "Value": 30
-    },
-    {
-      "Level": 2,
-      "Pointer": 2,
-      "Id": "War2",
-      "Type": 2,
-      "Value": 50
-    },
-    {
-      "Level": 3,
-      "Pointer": 2,
-      "Id": "War2",
-      "Type": 2,
-      "Value": 70
-    },
-    {
-      "Level": 4,
-      "Pointer": 2,
-      "Id": "War2",
-      "Type": 2,
-      "Value": 90
-    },
-    {
-      "Level": 3,
-      "Pointer": 3,
-      "Id": "War3",
-      "Type": 2,
-      "Value": 250
-    },
-    {
-      "Level": 4,
-      "Pointer": 3,
-      "Id": "War3",
-      "Type": 2,
-      "Value": 250
-    },
-    {
-      "Level": 3,
-      "Pointer": 4,
-      "Id": "War4",
-      "Type": 2,
-      "Value": 350
-    },
-    {
-      "Level": 4,
-      "Pointer": 4,
-      "Id": "War4",
-      "Type": 2,
-      "Value": 350
     },
     {
       "Id": "alev",
@@ -89,24 +26,6 @@
     {
       "Id": "alsk",
       "Value": 1
-    },
-    {
-      "Level": 2,
-      "Id": "atar",
-      "Type": 3,
-      "Value": "enemies,ground,neutral"
-    },
-    {
-      "Level": 3,
-      "Id": "atar",
-      "Type": 3,
-      "Value": "enemies,ground,neutral"
-    },
-    {
-      "Level": 4,
-      "Id": "atar",
-      "Type": 3,
-      "Value": "enemies,ground,neutral"
     },
     {
       "Id": "aart",
@@ -157,46 +76,10 @@
       "Value": "Abilities\\Weapons\\GryphonRiderMissile\\GryphonRiderMissileTarget.mdl"
     },
     {
-      "Level": 2,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Storm Hammers - [|cffffcc00Level 2|r]"
-    },
-    {
-      "Level": 3,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Storm Hammers - [|cffffcc00Level 3|r]"
-    },
-    {
-      "Level": 4,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Storm Hammers - [|cffffcc00Level 4|r]"
-    },
-    {
       "Level": 1,
       "Id": "aub1",
       "Type": 3,
       "Value": "Gives a 20% chance that an attack will deal 30 damage to nearby units."
-    },
-    {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Gives a 25% chance that an attack will deal 50 damage to nearby units."
-    },
-    {
-      "Level": 3,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Gives a 30% chance that an attack will deal 70 damage to nearby units."
-    },
-    {
-      "Level": 4,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Gives a 35% chance that an attack will deal 90 damage to nearby units."
     }
   ]
 }

--- a/mapdata/WarcraftLegacies/AbilityData/ABE1.json
+++ b/mapdata/WarcraftLegacies/AbilityData/ABE1.json
@@ -66,11 +66,6 @@
       "Value": "Q"
     },
     {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Summons immobile serpentine wards to attack the caster\u0027s enemies. The wards are immune to magic. |nLasts \u003CArsw,Dur1\u003E seconds. |n|n|cffffcc00Attacks land and air units.|r |n|n|cffffcc00Level 1|r - \u003CArsw,DataA1\u003E wards, \u003Cosp1,realHP\u003E hit points, \u003Cosp1,mindmg1\u003E - \u003Cosp1,maxdmg1\u003E damage. |n|cffffcc00Level 2|r - \u003CArsw,DataA2\u003E wards, \u003Cosp2,realHP\u003E hit points, \u003Cosp2,mindmg1\u003E - \u003Cosp2,maxdmg1\u003E damage. |n|cffffcc00Level 3|r - \u003CArsw,DataA3\u003E wards, \u003Cosp3,realHP\u003E hit points, \u003Cosp3,mindmg1\u003E - \u003Cosp3,maxdmg1\u003E damage. |n|cffffcc00Level 4|r - \u003CArsw,DataA4\u003E wards, \u003Cosp4,realHP\u003E hit points, \u003Cosp4,mindmg1\u003E - \u003Cosp4,maxdmg1\u003E damage."
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/ABE1.json
+++ b/mapdata/WarcraftLegacies/AbilityData/ABE1.json
@@ -11,39 +11,6 @@
       "Value": 125
     },
     {
-      "Level": 2,
-      "Id": "amcs",
-      "Value": 90
-    },
-    {
-      "Level": 3,
-      "Id": "amcs",
-      "Value": 105
-    },
-    {
-      "Level": 4,
-      "Id": "amcs",
-      "Value": 120
-    },
-    {
-      "Level": 2,
-      "Pointer": 1,
-      "Id": "Hwe2",
-      "Value": 4
-    },
-    {
-      "Level": 3,
-      "Pointer": 1,
-      "Id": "Hwe2",
-      "Value": 4
-    },
-    {
-      "Level": 4,
-      "Pointer": 1,
-      "Id": "Hwe2",
-      "Value": 4
-    },
-    {
       "Level": 1,
       "Id": "Hwe1",
       "Type": 3,
@@ -110,46 +77,10 @@
       "Value": "Obelisk of Nyalotha"
     },
     {
-      "Level": 2,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Serpent Ward (|cffffcc00Q|r) - [|cffffcc00Level 2|r]"
-    },
-    {
-      "Level": 3,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Serpent Ward (|cffffcc00Q|r) - [|cffffcc00Level 3|r]"
-    },
-    {
-      "Level": 4,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Serpent Ward (|cffffcc00Q|r) - [|cffffcc00Level 4|r]"
-    },
-    {
       "Level": 1,
       "Id": "aub1",
       "Type": 3,
       "Value": "Summons 1 Obelisk. The Obelisk has \u003Cn0BA,HP\u003E hit points and has Devotion, Command and Unholy Aura. |nLasts \u003CABE1,DUR1\u003E seconds."
-    },
-    {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Summons \u003CArsw,DataA2\u003E immobile serpentine wards to attack enemies. The ward has \u003Cosp2,realHP\u003E hit points, is magic immune, and deals \u003Cosp2,mindmg1\u003E - \u003Cosp2,maxdmg1\u003E damage. |nLasts \u003CArsw,Dur2\u003E seconds. |n|n|cffffcc00Attacks land and air units.|r"
-    },
-    {
-      "Level": 3,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Summons \u003CArsw,DataA3\u003E immobile serpentine wards to attack enemies. The ward has \u003Cosp3,realHP\u003E hit points, is magic immune, and deals \u003Cosp3,mindmg1\u003E - \u003Cosp3,maxdmg1\u003E damage. |nLasts \u003CArsw,Dur3\u003E seconds. |n|n|cffffcc00Attacks land and air units.|r"
-    },
-    {
-      "Level": 4,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Summons \u003CArsw,DataA4\u003E immobile serpentine wards to attack enemies. The ward has \u003Cosp4,realHP\u003E hit points, is magic immune, and deals \u003Cosp4,mindmg1\u003E - \u003Cosp4,maxdmg1\u003E damage. |nLasts \u003CArsw,Dur4\u003E seconds. |n|n|cffffcc00Attacks land and air units.|r"
     },
     {
       "Id": "anam",

--- a/mapdata/WarcraftLegacies/AbilityData/ABSS.json
+++ b/mapdata/WarcraftLegacies/AbilityData/ABSS.json
@@ -229,11 +229,6 @@
       "Value": "Q"
     },
     {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Hurls a poisoned dagger which deals large initial damage, and then deals damage over time. The poisoned unit has its movement speed slowed by 75% for it\u0027s duration. Lasts 15 seconds on units and Heroes.|n|n|cffffcc00Level 1|r - \u003CAEsh,DataE1\u003E strike damage, \u003CAEsh,DataA1\u003E duration damage. |n|cffffcc00Level 2|r - \u003CAEsh,DataE2\u003E strike damage, \u003CAEsh,DataA2\u003E duration damage. |n|cffffcc00Level 3|r - \u003CAEsh,DataE3\u003E strike damage, \u003CAEsh,DataA3\u003E duration damage.|n|cffffcc00Level 4|r - \u003CAEsh,DataE4\u003E strike damage, \u003CAEsh,DataA4\u003E duration damage."
-    },
-    {
       "Level": 4,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/ADCS.json
+++ b/mapdata/WarcraftLegacies/AbilityData/ADCS.json
@@ -11,16 +11,6 @@
       "Value": 300
     },
     {
-      "Level": 3,
-      "Id": "amcs",
-      "Value": 125
-    },
-    {
-      "Level": 4,
-      "Id": "amcs",
-      "Value": 150
-    },
-    {
       "Level": 1,
       "Pointer": 1,
       "Id": "Htb1",
@@ -28,36 +18,10 @@
       "Value": 0
     },
     {
-      "Level": 3,
-      "Pointer": 1,
-      "Id": "Htb1",
-      "Type": 2,
-      "Value": 250
-    },
-    {
-      "Level": 4,
-      "Pointer": 1,
-      "Id": "Htb1",
-      "Type": 2,
-      "Value": 300
-    },
-    {
       "Level": 1,
       "Id": "adur",
       "Type": 2,
       "Value": 1
-    },
-    {
-      "Level": 3,
-      "Id": "adur",
-      "Type": 2,
-      "Value": 6
-    },
-    {
-      "Level": 4,
-      "Id": "adur",
-      "Type": 2,
-      "Value": 7
     },
     {
       "Level": 1,
@@ -70,12 +34,6 @@
       "Id": "ahdu",
       "Type": 2,
       "Value": 0.3
-    },
-    {
-      "Level": 4,
-      "Id": "ahdu",
-      "Type": 2,
-      "Value": 3.5
     },
     {
       "Id": "alev",
@@ -92,18 +50,6 @@
       "Id": "aran",
       "Type": 2,
       "Value": 99999
-    },
-    {
-      "Level": 3,
-      "Id": "aran",
-      "Type": 2,
-      "Value": 700
-    },
-    {
-      "Level": 4,
-      "Id": "aran",
-      "Type": 2,
-      "Value": 700
     },
     {
       "Id": "aher",
@@ -186,18 +132,6 @@
       "Value": "Crystal Discharge - [|cffffcc00Level 2|r]"
     },
     {
-      "Level": 3,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Greater Storm Bolt (|cffffcc00Q|r) - [|cffffcc00Level 3|r]"
-    },
-    {
-      "Level": 4,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Greater Storm Bolt (|cffffcc00Q|r) - [|cffffcc00Level 4|r]"
-    },
-    {
       "Level": 1,
       "Id": "aub1",
       "Type": 3,
@@ -208,18 +142,6 @@
       "Id": "aub1",
       "Type": 3,
       "Value": "Launches a Crystal at a target enemy unit anywhere on the map, stunning the target for \u003CADCS,Dur2\u003E seconds. (\u003CADCS,HeroDur2,.\u003E for heroes)"
-    },
-    {
-      "Level": 3,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Throws a magical hammer at a target enemy unit, dealing 350 damage and stunning the target for 6 seconds. Lasts 3 seconds on heroes."
-    },
-    {
-      "Level": 4,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Throws a magical hammer at a target enemy unit, dealing 400 damage and stunning the target for 7 seconds. Lasts 3.5 seconds on heroes."
     },
     {
       "Id": "aart",

--- a/mapdata/WarcraftLegacies/AbilityData/ADCS.json
+++ b/mapdata/WarcraftLegacies/AbilityData/ADCS.json
@@ -110,16 +110,6 @@
       "Value": "Q"
     },
     {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Greater Storm Bolt (|cffffcc00Q|r) - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "A magical hammer that is thrown at an enemy unit, causing damage and stunning the target. |n|n|cffffcc00Level 1|r - 250 damage, 4 second stun. 2 second on Heroes.|n|cffffcc00Level 2|r - 300 damage, 5 second stun. 2.5 seconds on Heroes.|n|cffffcc00Level 3|r - 350 damage, 6 second stun. 3 seconds on Heroes.|n|cffffcc00Level 4|r - 400 damage, 7 second stun. 3.5 seconds on Heroes"
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/AEKS.json
+++ b/mapdata/WarcraftLegacies/AbilityData/AEKS.json
@@ -77,11 +77,6 @@
       "Value": "Summon Elekks"
     },
     {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Summon Fel Hounds - [|cffffcc00Level %d|r]"
-    },
-    {
       "Id": "anam",
       "Type": 3,
       "Value": "Summon Elekks"
@@ -90,11 +85,6 @@
       "Id": "aart",
       "Type": 3,
       "Value": "ReplaceableTextures\\CommandButtons\\BTNElephant.blp"
-    },
-    {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTNFelHound.blp"
     },
     {
       "Id": "arpx",

--- a/mapdata/WarcraftLegacies/AbilityData/AEst.json
+++ b/mapdata/WarcraftLegacies/AbilityData/AEst.json
@@ -55,16 +55,6 @@
       "Value": "Q"
     },
     {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Scout (|cffffcc00Q|r) - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Temporarily summons an Owl Scout, which can be used to scout the map. |nCan see invisible units. |n|n|cffffcc00Level 1|r - Summons an Owl Scout for \u003CAEst,Cost1\u003E mana. |n|cffffcc00Level 2|r - Summons a better Owl Scout for \u003CAEst,Cost2\u003E mana. |n|cffffcc00Level 3|r - Summons a better Owl Scout for \u003CAEst,Cost3\u003E mana. |n|cffffcc00Level 4|r - Summons 2 of the best Owl Scout for \u003CAEst,Cost4\u003E mana. |n|cffffcc00Level 5|r - Summons 3 of the best Owl Scout for \u003CAEst,Cost5\u003E mana."
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/AL1A.json
+++ b/mapdata/WarcraftLegacies/AbilityData/AL1A.json
@@ -72,16 +72,6 @@
       "Value": "Q"
     },
     {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Mana Burn (|cffffcc00Q|r) - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Sends a bolt of negative energy that burns a target enemy unit\u0027s mana. Burned mana combusts, dealing damage to the target equal to the amount of mana burned. |n|n|cffffcc00Level 1|r - Burns up to 100 mana. |n|cffffcc00Level 2|r - Burns up to 160 mana. |n|cffffcc00Level 3|r - Burns up to 220 mana.|n|cffffcc00Level 4|r - Burns up to 280 mana.|n|cffffcc00Level 5|r - Burns up to 340 mana."
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/ANMC.json
+++ b/mapdata/WarcraftLegacies/AbilityData/ANMC.json
@@ -12,67 +12,13 @@
       "Value": 450
     },
     {
-      "Level": 2,
-      "Id": "aare",
-      "Type": 2,
-      "Value": 200
-    },
-    {
-      "Level": 3,
-      "Id": "aare",
-      "Type": 2,
-      "Value": 250
-    },
-    {
-      "Level": 4,
-      "Id": "aare",
-      "Type": 2,
-      "Value": 275
-    },
-    {
       "Level": 1,
       "Id": "abuf",
       "Type": 3,
       "Value": "B00S"
     },
     {
-      "Level": 2,
-      "Id": "abuf",
-      "Type": 3,
-      "Value": "B00S"
-    },
-    {
-      "Level": 3,
-      "Id": "abuf",
-      "Type": 3,
-      "Value": "B00S"
-    },
-    {
-      "Level": 4,
-      "Id": "abuf",
-      "Type": 3,
-      "Value": "B00S"
-    },
-    {
       "Level": 1,
-      "Pointer": 1,
-      "Id": "Nsi1",
-      "Value": 3
-    },
-    {
-      "Level": 2,
-      "Pointer": 1,
-      "Id": "Nsi1",
-      "Value": 3
-    },
-    {
-      "Level": 3,
-      "Pointer": 1,
-      "Id": "Nsi1",
-      "Value": 3
-    },
-    {
-      "Level": 4,
       "Pointer": 1,
       "Id": "Nsi1",
       "Value": 3
@@ -84,46 +30,10 @@
       "Value": 30
     },
     {
-      "Level": 2,
-      "Id": "adur",
-      "Type": 2,
-      "Value": 4
-    },
-    {
-      "Level": 3,
-      "Id": "adur",
-      "Type": 2,
-      "Value": 5
-    },
-    {
-      "Level": 4,
-      "Id": "adur",
-      "Type": 2,
-      "Value": 6
-    },
-    {
       "Level": 1,
       "Id": "ahdu",
       "Type": 2,
       "Value": 10
-    },
-    {
-      "Level": 2,
-      "Id": "ahdu",
-      "Type": 2,
-      "Value": 2.75
-    },
-    {
-      "Level": 3,
-      "Id": "ahdu",
-      "Type": 2,
-      "Value": 3.5
-    },
-    {
-      "Level": 4,
-      "Id": "ahdu",
-      "Type": 2,
-      "Value": 4.25
     },
     {
       "Id": "alev",
@@ -215,46 +125,10 @@
       "Value": "Mind Confusion"
     },
     {
-      "Level": 2,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Mind Confusion - [|cffffcc00Level 2|r]"
-    },
-    {
-      "Level": 3,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Mind Confusion - [|cffffcc00Level 3|r]"
-    },
-    {
-      "Level": 4,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Mind Confusion - [|cffffcc00Level 4|r]"
-    },
-    {
       "Level": 1,
       "Id": "aub1",
       "Type": 3,
       "Value": "Stops all enemies in a small target area from attacking for 30(10) seconds."
-    },
-    {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Stops all enemies in a small target area from attacking for 4(2.75) seconds."
-    },
-    {
-      "Level": 3,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Stops all enemies in a small target area from attacking for 5(3.5) seconds."
-    },
-    {
-      "Level": 4,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Stops all enemies in a small target area from attacking for 6(4.25) seconds."
     }
   ]
 }

--- a/mapdata/WarcraftLegacies/AbilityData/ANMC.json
+++ b/mapdata/WarcraftLegacies/AbilityData/ANMC.json
@@ -95,11 +95,6 @@
       "Value": "Mind Confusion"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTNHellstalker.blp"
-    },
-    {
       "Id": "arpx",
       "Value": 1
     },
@@ -107,16 +102,6 @@
       "Id": "arhk",
       "Type": 3,
       "Value": "W"
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Mind Confusion - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "The hero\u0027s masterful trickery stops enemy units from attacking for a short period of time. |n|n|cffffcc00Level 1|r - Small area, lasts 3(2) seconds. |n|cffffcc00Level 2|r - Medium area, lasts 4(2.75) seconds. |n|cffffcc00Level 3|r - Large area, lasts 5(3.5) seconds.|n|cffffcc00Level 4|r - Very large area, lasts 6(4.25) seconds."
     },
     {
       "Level": 1,

--- a/mapdata/WarcraftLegacies/AbilityData/ANs1.json
+++ b/mapdata/WarcraftLegacies/AbilityData/ANs1.json
@@ -63,16 +63,6 @@
       "Value": "Q"
     },
     {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn (|cffffcc00Q|r) Pocket Factory - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Creates a factory which automatically constructs Clockwerk Goblins. These artificial Goblins, in addition to being potent attackers, explode upon death, causing damage to nearby enemy units. |n|n|cffffcc00Level 1|r - Explosion does 30 damage.|n|cffffcc00Level 2|r - Explosion does 60 damage.|n|cffffcc00Level 3|r - Explosion does 80 damage. |n|cffffcc00Level 4|r - Explosion does 100 damage.|nFactory lasts 40 seconds."
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/AOr3.json
+++ b/mapdata/WarcraftLegacies/AbilityData/AOr3.json
@@ -42,11 +42,6 @@
       "Value": 1
     },
     {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "When killed, the Hero will come back to life. |n|n|cffffcc00Level 1|r - \u003CAOr3,Cool1\u003E second cooldown. |n|cffffcc00Level 2|r - \u003CAOr3,Cool2\u003E second cooldown."
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/AUau.json
+++ b/mapdata/WarcraftLegacies/AbilityData/AUau.json
@@ -77,24 +77,9 @@
       "Value": "Invigoration"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTNResurrection.blp"
-    },
-    {
       "Id": "arhk",
       "Type": 3,
       "Value": "E"
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": ""
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Increases the movement speed and life regeneration rate of nearby friendly units. |n|n|cffffcc00Level 1|r - \u003CAUau,DataA1,%\u003E% movement, 0.80 HP regeneration bonus. |n|cffffcc00Level 2|r - \u003CAUau,DataA2,%\u003E% movement, 1.30 HP regeneration bonus. |n|cffffcc00Level 3|r - \u003CAUau,DataA3,%\u003E% movement, 1.80 HP regeneration bonus. |n|cffffcc00Level 4|r - \u003CAUau,DataA4,%\u003E% movement, 2.30 HP regeneration bonus."
     },
     {
       "Level": 1,

--- a/mapdata/WarcraftLegacies/AbilityData/AXK1.json
+++ b/mapdata/WarcraftLegacies/AbilityData/AXK1.json
@@ -77,11 +77,6 @@
       "Value": "Q"
     },
     {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "The Warden hurls a flurry of knives, damaging nearby enemies. |n|n|cffffcc00Level 1|r - \u003CAEfk,DataA1\u003E damage per target. |n|cffffcc00Level 2|r - \u003CAEfk,DataA2\u003E damage per target. |n|cffffcc00Level 3|r - \u003CAEfk,DataA3\u003E damage per target. |n|cffffcc00Level 4|r - \u003CAEfk,DataA4\u003E damage per target."
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/AXK2.json
+++ b/mapdata/WarcraftLegacies/AbilityData/AXK2.json
@@ -21,12 +21,6 @@
       "Value": "Causes the caster to fire 2 voidbolts at 2 random targets whenever he casts a spell, dealing \u003CAXK1,DataA1\u003E damage each."
     },
     {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Increases the rate at which this unit gathers lumber."
-    },
-    {
       "Id": "aart",
       "Type": 3,
       "Value": "ReplaceableTextures\\PassiveButtons\\PASVoidRift_12.blp"

--- a/mapdata/WarcraftLegacies/AbilityData/AZ2A.json
+++ b/mapdata/WarcraftLegacies/AbilityData/AZ2A.json
@@ -64,11 +64,6 @@
       "Value": "E"
     },
     {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Transfers mana between the Blood Mage and a target. Drains mana from an enemy, or transfers mana to an ally.|n|nSiphon Mana can push the Blood Mage\u0027s mana over its maximum value, though excess mana drains off rapidly if not used.|nLasts \u003CAHdr,Dur1\u003E seconds.|n|n|cffffcc00Level 1|r - \u003CAHdr,DataB1\u003E mana drained per second. |n|cffffcc00Level 2|r - \u003CAHdr,DataB2\u003E mana drained per second. |n|cffffcc00Level 3|r - \u003CAHdr,DataB3\u003E mana drained per second. |n|cffffcc00Level 4|r - \u003CAHdr,DataB4\u003E mana drained per second. |n|cffffcc00Level 5|r - \u003CAHdr,DataB5\u003E mana drained per second."
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/HWP1.json
+++ b/mapdata/WarcraftLegacies/AbilityData/HWP1.json
@@ -6,86 +6,11 @@
   ],
   "Modifications": [
     {
-      "Level": 2,
-      "Id": "amcs",
-      "Value": 105
-    },
-    {
-      "Level": 3,
-      "Id": "amcs",
-      "Value": 120
-    },
-    {
-      "Level": 4,
-      "Id": "amcs",
-      "Value": 135
-    },
-    {
       "Level": 1,
       "Pointer": 1,
       "Id": "Ocl1",
       "Type": 2,
       "Value": 0
-    },
-    {
-      "Level": 2,
-      "Pointer": 1,
-      "Id": "Ocl1",
-      "Type": 2,
-      "Value": 230
-    },
-    {
-      "Level": 3,
-      "Pointer": 1,
-      "Id": "Ocl1",
-      "Type": 2,
-      "Value": 320
-    },
-    {
-      "Level": 4,
-      "Pointer": 1,
-      "Id": "Ocl1",
-      "Type": 2,
-      "Value": 410
-    },
-    {
-      "Level": 2,
-      "Pointer": 2,
-      "Id": "Ocl2",
-      "Value": 5
-    },
-    {
-      "Level": 3,
-      "Pointer": 2,
-      "Id": "Ocl2",
-      "Value": 6
-    },
-    {
-      "Level": 4,
-      "Pointer": 2,
-      "Id": "Ocl2",
-      "Value": 7
-    },
-    {
-      "Level": 2,
-      "Pointer": 3,
-      "Id": "Ocl3",
-      "Type": 2,
-      "Value": 0.2
-    },
-    {
-      "Level": 3,
-      "Pointer": 3,
-      "Id": "Ocl3",
-      "Type": 2,
-      "Value": 0.15
-    },
-    {
-      "Level": 4,
-      "Pointer": 3,
-      "Id": "Ocl3",
-      "Type": 2,
-      "Value": 0.1
     },
     {
       "Id": "aher",
@@ -150,24 +75,6 @@
       "Value": "Calls forth a wave of healing energy that bounces up to 3 times. The primary target is healed for 100, each subsequent bounce heals 10% less. If the last healed unit dies within 20 seconds, the wave continues on to nearby targets.\r\n"
     },
     {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Calls forth a wave of healing energy that bounces up to \u003CA0RR,DataB2\u003E times, healing \u003CA0RR,DataA2\u003E damage on the primary target. Each jump heals 20% less."
-    },
-    {
-      "Level": 3,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Calls forth a wave of healing energy that bounces up to \u003CA0RR,DataB3\u003E times, healing \u003CA0RR,DataA3\u003E damage on the primary target. Each jump heals 15% less."
-    },
-    {
-      "Level": 4,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Calls forth a wave of healing energy that bounces up to \u003CA0RR,DataB4\u003E times, healing \u003CA0RR,DataA4\u003E damage on the primary target. Each jump heals 10% less."
-    },
-    {
       "Id": "atat",
       "Type": 3,
       "Value": "Abilities\\Spells\\NightElf\\MoonWell\\MoonWellCasterArt.mdl"
@@ -206,24 +113,6 @@
       "Id": "atp1",
       "Type": 3,
       "Value": "Energy Wave - [|cffffcc00Level 1|r]"
-    },
-    {
-      "Level": 2,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Energy Wave - [|cffffcc00Level 2|r]"
-    },
-    {
-      "Level": 3,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Energy Wave - [|cffffcc00Level 3|r]"
-    },
-    {
-      "Level": 4,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Energy Wave - [|cffffcc00Level 4|r]"
     },
     {
       "Id": "abpx",

--- a/mapdata/WarcraftLegacies/AbilityData/HWP1.json
+++ b/mapdata/WarcraftLegacies/AbilityData/HWP1.json
@@ -64,11 +64,6 @@
       "Value": "W"
     },
     {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Calls forth a wave of energy that heals a target and bounces to nearby friendlies. Each bounce heals less damage. |n|n|cffffcc00Level 1|r - Heals \u003CANhw,DataA1\u003E damage, jumps \u003CANhw,DataB1\u003E times, 25% less healing per jump.|n|cffffcc00Level 2|r - Heals \u003CANhw,DataA2\u003E damage, jumps \u003CANhw,DataB2\u003E times, 20% less healing per jump.|n|cffffcc00Level 3|r - Heals \u003CANhw,DataA3\u003E damage, jumps \u003CANhw,DataB3\u003E times, 15% less healing per jump.|n|cffffcc00Level 4|r - Heals \u003CANhw,DataA4\u003E damage, jumps \u003CANhw,DataB4\u003E times, 10% less healing per jump."
-    },
-    {
       "Level": 1,
       "Id": "aub1",
       "Type": 3,
@@ -94,19 +89,9 @@
       "Value": "ReplaceableTextures\\CommandButtons\\BTNFelBurn.blp"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTNFelBurn.blp"
-    },
-    {
       "Id": "anam",
       "Type": 3,
       "Value": "Energy Wave"
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Energy Wave - [|cffffcc00Level %d|r]"
     },
     {
       "Level": 1,

--- a/mapdata/WarcraftLegacies/AbilityData/MD06.json
+++ b/mapdata/WarcraftLegacies/AbilityData/MD06.json
@@ -6,51 +6,11 @@
   ],
   "Modifications": [
     {
-      "Level": 2,
-      "Id": "amcs",
-      "Value": 75
-    },
-    {
-      "Level": 3,
-      "Id": "amcs",
-      "Value": 85
-    },
-    {
-      "Level": 4,
-      "Id": "amcs",
-      "Value": 95
-    },
-    {
-      "Level": 4,
-      "Pointer": 1,
-      "Id": "Hhb1",
-      "Type": 2,
-      "Value": 800
-    },
-    {
       "Id": "alev",
       "Value": 1
     },
     {
       "Level": 1,
-      "Id": "atar",
-      "Type": 3,
-      "Value": "air,ground,invulnerable,nonancient,organic,vulnerable"
-    },
-    {
-      "Level": 2,
-      "Id": "atar",
-      "Type": 3,
-      "Value": "air,ground,invulnerable,nonancient,organic,vulnerable"
-    },
-    {
-      "Level": 3,
-      "Id": "atar",
-      "Type": 3,
-      "Value": "air,ground,invulnerable,nonancient,organic,vulnerable"
-    },
-    {
-      "Level": 4,
       "Id": "atar",
       "Type": 3,
       "Value": "air,ground,invulnerable,nonancient,organic,vulnerable"
@@ -80,34 +40,10 @@
       "Value": "A holy light that can heal a friendly living unit or damage an enemy Undead unit. |n|n|cffffcc00Level 1|r - Heals for 200 hit points. |n|cffffcc00Level 2|r - Heals for 400 hit points. |n|cffffcc00Level 3|r - Heals for 600 hit points. |n|cffffcc00Level 4|r - Heals for 800 hit points."
     },
     {
-      "Level": 4,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Holy Light - [|cffffcc00Level 4|r]"
-    },
-    {
       "Level": 1,
       "Id": "aub1",
       "Type": 3,
       "Value": "A holy light that can heal a friendly living unit for \u003CMD06,DataA1\u003E or deal half damage to an enemy Undead unit."
-    },
-    {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "A holy light that can heal a friendly living unit for 400 or deal half damage to an enemy Undead unit."
-    },
-    {
-      "Level": 3,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "A holy light that can heal a friendly living unit for 600 or deal half damage to an enemy Undead unit."
-    },
-    {
-      "Level": 4,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "A holy light that can heal a friendly living unit for 800 or deal half damage to an enemy Undead unit."
     },
     {
       "Level": 1,

--- a/mapdata/WarcraftLegacies/AbilityData/MD06.json
+++ b/mapdata/WarcraftLegacies/AbilityData/MD06.json
@@ -35,11 +35,6 @@
       "Value": "D"
     },
     {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "A holy light that can heal a friendly living unit or damage an enemy Undead unit. |n|n|cffffcc00Level 1|r - Heals for 200 hit points. |n|cffffcc00Level 2|r - Heals for 400 hit points. |n|cffffcc00Level 3|r - Heals for 600 hit points. |n|cffffcc00Level 4|r - Heals for 800 hit points."
-    },
-    {
       "Level": 1,
       "Id": "aub1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/SLS0.json
+++ b/mapdata/WarcraftLegacies/AbilityData/SLS0.json
@@ -89,11 +89,6 @@
       "Value": "W"
     },
     {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Summons \u003CAOsf,DataB1\u003E Spirit Wolves to fight the Far Seer\u0027s enemies. |nLasts \u003CAOsf,Dur1\u003E seconds. |n|n|cffffcc00Level 1|r - \u003Cosw1,realHP\u003E hit points, \u003Cosw1,mindmg1\u003E - \u003Cosw1,maxdmg1\u003E damage. 2 wolves summoned.|n|cffffcc00Level 2|r - \u003Cosw2,realHP\u003E hit points, \u003Cosw2,mindmg1\u003E - \u003Cosw2,maxdmg1\u003E damage and Critical Strike. 2 wolves summoned.|n|cffffcc00Level 3|r - \u003Cosw3,realHP\u003E hit points, \u003Cosw3,mindmg1\u003E - \u003Cosw3,maxdmg1\u003E damage and Critical Strike. 2 wolves summoned.|n|cffffcc00Level 4|r - \u003Cosw3,realHP\u003E hit points, \u003Cosw3,mindmg1\u003E - \u003Cosw3,maxdmg1\u003E damage, and Critical Strike. 4 wolves summoned.|n|cffffcc00Level 5|r - \u003Cosw3,realHP\u003E hit points, \u003Cosw3,mindmg1\u003E - \u003Cosw3,maxdmg1\u003E damage and Critical Strike. 6 wolves summoned.|n"
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/SLS9.json
+++ b/mapdata/WarcraftLegacies/AbilityData/SLS9.json
@@ -207,11 +207,6 @@
       "Value": "W"
     },
     {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Summons \u003CAOsf,DataB1\u003E Spirit Wolves to fight the Far Seer\u0027s enemies. |nLasts \u003CAOsf,Dur1\u003E seconds. |n|n|cffffcc00Level 1|r - \u003Cosw1,realHP\u003E hit points, \u003Cosw1,mindmg1\u003E - \u003Cosw1,maxdmg1\u003E damage. 2 wolves summoned.|n|cffffcc00Level 2|r - \u003Cosw2,realHP\u003E hit points, \u003Cosw2,mindmg1\u003E - \u003Cosw2,maxdmg1\u003E damage and Critical Strike. 2 wolves summoned.|n|cffffcc00Level 3|r - \u003Cosw3,realHP\u003E hit points, \u003Cosw3,mindmg1\u003E - \u003Cosw3,maxdmg1\u003E damage and Critical Strike. 2 wolves summoned.|n|cffffcc00Level 4|r - \u003Cosw3,realHP\u003E hit points, \u003Cosw3,mindmg1\u003E - \u003Cosw3,maxdmg1\u003E damage, and Critical Strike. 4 wolves summoned.|n|cffffcc00Level 5|r - \u003Cosw3,realHP\u003E hit points, \u003Cosw3,mindmg1\u003E - \u003Cosw3,maxdmg1\u003E damage and Critical Strike. 6 wolves summoned.|n"
-    },
-    {
       "Id": "auhk",
       "Type": 3,
       "Value": "Z"

--- a/mapdata/WarcraftLegacies/AbilityData/ST9J.json
+++ b/mapdata/WarcraftLegacies/AbilityData/ST9J.json
@@ -18,12 +18,6 @@
       "Value": 1
     },
     {
-      "Level": 4,
-      "Id": "aare",
-      "Type": 2,
-      "Value": 600
-    },
-    {
       "Level": 1,
       "Id": "abuf",
       "Type": 3,
@@ -37,12 +31,6 @@
     },
     {
       "Level": 3,
-      "Id": "abuf",
-      "Type": 3,
-      "Value": "B0B2"
-    },
-    {
-      "Level": 4,
       "Id": "abuf",
       "Type": 3,
       "Value": "B0B2"
@@ -66,12 +54,6 @@
       "Value": 60
     },
     {
-      "Level": 4,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 120
-    },
-    {
       "Level": 2,
       "Id": "amcs",
       "Value": 150
@@ -80,11 +62,6 @@
       "Level": 3,
       "Id": "amcs",
       "Value": 150
-    },
-    {
-      "Level": 4,
-      "Id": "amcs",
-      "Value": 250
     },
     {
       "Level": 1,
@@ -112,12 +89,6 @@
       "Value": 0.001
     },
     {
-      "Level": 4,
-      "Id": "adur",
-      "Type": 2,
-      "Value": 25
-    },
-    {
       "Id": "aher",
       "Value": 1
     },
@@ -140,12 +111,6 @@
       "Value": 0.001
     },
     {
-      "Level": 4,
-      "Id": "ahdu",
-      "Type": 2,
-      "Value": 25
-    },
-    {
       "Id": "alev",
       "Value": 3
     },
@@ -166,12 +131,6 @@
     },
     {
       "Level": 3,
-      "Id": "atar",
-      "Type": 3,
-      "Value": "self"
-    },
-    {
-      "Level": 4,
       "Id": "atar",
       "Type": 3,
       "Value": "self"
@@ -254,12 +213,6 @@
       "Value": "Vanish - [|cffffcc00Level 3|r]"
     },
     {
-      "Level": 4,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Vanish - [|cffffcc00Level 4|r]"
-    },
-    {
       "Level": 1,
       "Id": "aub1",
       "Type": 3,
@@ -276,12 +229,6 @@
       "Id": "aub1",
       "Type": 3,
       "Value": "The hero vanishes, becoming invisible and gaining \u003CST8K,DataA1\u003E damage for 20 seconds. The invisibility will not dissipate even if the hero attacks or casts spells."
-    },
-    {
-      "Level": 4,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Gives friendly nearby units invulnerable. Lasts 4 seconds."
     },
     {
       "Id": "aani",

--- a/mapdata/WarcraftLegacies/AbilityData/TPY1.json
+++ b/mapdata/WarcraftLegacies/AbilityData/TPY1.json
@@ -30,17 +30,6 @@
       "Value": 12
     },
     {
-      "Level": 5,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 10
-    },
-    {
-      "Level": 5,
-      "Id": "amcs",
-      "Value": 90
-    },
-    {
       "Level": 1,
       "Pointer": 1,
       "Id": "Owk1",
@@ -63,13 +52,6 @@
     },
     {
       "Level": 4,
-      "Pointer": 1,
-      "Id": "Owk1",
-      "Type": 2,
-      "Value": 1
-    },
-    {
-      "Level": 5,
       "Pointer": 1,
       "Id": "Owk1",
       "Type": 2,
@@ -97,13 +79,6 @@
       "Value": 0.45
     },
     {
-      "Level": 5,
-      "Pointer": 2,
-      "Id": "Owk2",
-      "Type": 2,
-      "Value": 0.4
-    },
-    {
       "Level": 1,
       "Pointer": 3,
       "Id": "Owk3",
@@ -125,13 +100,6 @@
       "Value": 85
     },
     {
-      "Level": 5,
-      "Pointer": 3,
-      "Id": "Owk3",
-      "Type": 2,
-      "Value": 125
-    },
-    {
       "Level": 2,
       "Id": "adur",
       "Type": 2,
@@ -150,12 +118,6 @@
       "Value": 20
     },
     {
-      "Level": 5,
-      "Id": "adur",
-      "Type": 2,
-      "Value": 20
-    },
-    {
       "Level": 2,
       "Id": "ahdu",
       "Type": 2,
@@ -169,12 +131,6 @@
     },
     {
       "Level": 4,
-      "Id": "ahdu",
-      "Type": 2,
-      "Value": 20
-    },
-    {
-      "Level": 5,
       "Id": "ahdu",
       "Type": 2,
       "Value": 20
@@ -215,12 +171,6 @@
       "Value": "Phantom Step - [|cffffcc00Level 4|r]"
     },
     {
-      "Level": 5,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Wind Walk (|cffffcc00Q|r) - [|cffffcc00Level 5|r]"
-    },
-    {
       "Level": 1,
       "Id": "aub1",
       "Type": 3,
@@ -243,12 +193,6 @@
       "Id": "aub1",
       "Type": 3,
       "Value": "Allows the Hero to become invisible, and move \u003CTPY1,DataB4,%\u003E% faster for \u003CTPY1,Dur4\u003E seconds. If the Hero attacks a unit to break invisibility, the attack will do \u003CTPY1,DataC4\u003E bonus damage."
-    },
-    {
-      "Level": 5,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Allows the Hero to become invisible, and move \u003CAOwk,DataB5,%\u003E% faster for \u003CAOwk,Dur5\u003E seconds. If the Hero attacks a unit to break invisibility, the attack will do \u003CAOwk,DataC5\u003E bonus damage."
     },
     {
       "Id": "ansf",

--- a/mapdata/WarcraftLegacies/AbilityData/VP02.json
+++ b/mapdata/WarcraftLegacies/AbilityData/VP02.json
@@ -20,20 +20,6 @@
       "Value": 0
     },
     {
-      "Level": 3,
-      "Pointer": 1,
-      "Id": "Eev1",
-      "Type": 2,
-      "Value": 0
-    },
-    {
-      "Level": 4,
-      "Pointer": 1,
-      "Id": "Eev1",
-      "Type": 2,
-      "Value": 0
-    },
-    {
       "Id": "alev",
       "Value": 2
     },
@@ -89,18 +75,6 @@
       "Value": "Vampiric Siphon - [|cffffcc00Level 2|r]"
     },
     {
-      "Level": 3,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Warglaives of Azzinoth - [|cffffcc00Level 3|r]"
-    },
-    {
-      "Level": 4,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Warglaives of Azzinoth - [|cffffcc00Level 4|r]"
-    },
-    {
       "Level": 1,
       "Id": "aub1",
       "Type": 3,
@@ -111,18 +85,6 @@
       "Id": "aub1",
       "Type": 3,
       "Value": "Causes the hero to heal a moderate amount whenever they deal damage to an enemy. Scales with hero level."
-    },
-    {
-      "Level": 3,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Causes Illidan\u0027s attacks to deal 50 additional magic damage in an area around the attacked unit. Deals 20% extra damage to Demons."
-    },
-    {
-      "Level": 4,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Causes Illidan\u0027s attacks to deal 65 additional magic damage in an area around the attacked unit. Deals 20% extra damage to Demons."
     },
     {
       "Id": "arhk",

--- a/mapdata/WarcraftLegacies/AbilityData/VP02.json
+++ b/mapdata/WarcraftLegacies/AbilityData/VP02.json
@@ -48,21 +48,6 @@
       "Value": "Vampiric Siphon"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTNHeroDreadLord.blp"
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Vampiric Siphon - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Causes the hero to heal damage whenever they deal damage to an enemy. |n|n|cffffcc00Level 1|r - Heals 50 per unit hit. |n|cffffcc00Level 2|r - Heals 100 per unit hit."
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/VP08.json
+++ b/mapdata/WarcraftLegacies/AbilityData/VP08.json
@@ -20,20 +20,6 @@
       "Value": 0
     },
     {
-      "Level": 3,
-      "Pointer": 1,
-      "Id": "Eev1",
-      "Type": 2,
-      "Value": 0
-    },
-    {
-      "Level": 4,
-      "Pointer": 1,
-      "Id": "Eev1",
-      "Type": 2,
-      "Value": 0
-    },
-    {
       "Id": "alev",
       "Value": 2
     },
@@ -89,18 +75,6 @@
       "Value": "Vampiric Siphon - [|cffffcc00Level 2|r]"
     },
     {
-      "Level": 3,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Warglaives of Azzinoth - [|cffffcc00Level 3|r]"
-    },
-    {
-      "Level": 4,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Warglaives of Azzinoth - [|cffffcc00Level 4|r]"
-    },
-    {
       "Level": 1,
       "Id": "aub1",
       "Type": 3,
@@ -111,18 +85,6 @@
       "Id": "aub1",
       "Type": 3,
       "Value": "Causes the unit to heal a small amount whenever they deal damage to an enemy. Scales with upgrades."
-    },
-    {
-      "Level": 3,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Causes Illidan\u0027s attacks to deal 50 additional magic damage in an area around the attacked unit. Deals 20% extra damage to Demons."
-    },
-    {
-      "Level": 4,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Causes Illidan\u0027s attacks to deal 65 additional magic damage in an area around the attacked unit. Deals 20% extra damage to Demons."
     },
     {
       "Id": "arhk",

--- a/mapdata/WarcraftLegacies/AbilityData/VP08.json
+++ b/mapdata/WarcraftLegacies/AbilityData/VP08.json
@@ -48,21 +48,6 @@
       "Value": "Vampiric Siphon"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTNHeroDreadLord.blp"
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Vampiric Siphon - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Causes the hero to heal damage whenever they deal damage to an enemy. |n|n|cffffcc00Level 1|r - Heals 50 per unit hit. |n|cffffcc00Level 2|r - Heals 100 per unit hit."
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/Z3X2.json
+++ b/mapdata/WarcraftLegacies/AbilityData/Z3X2.json
@@ -21,12 +21,6 @@
       "Value": "Causes the caster to heal nearby allies for 50 hit points whenever they cast a spell."
     },
     {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Increases the rate at which this unit gathers lumber."
-    },
-    {
       "Id": "aart",
       "Type": 3,
       "Value": "ReplaceableTextures\\PassiveButtons\\PASHolyWipe.blp"

--- a/mapdata/WarcraftLegacies/AbilityData/Z3X9.json
+++ b/mapdata/WarcraftLegacies/AbilityData/Z3X9.json
@@ -70,11 +70,6 @@
       "Value": "Q"
     },
     {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "The Warden hurls a flurry of knives, damaging nearby enemies. |n|n|cffffcc00Level 1|r - \u003CAEfk,DataA1\u003E damage per target. |n|cffffcc00Level 2|r - \u003CAEfk,DataA2\u003E damage per target. |n|cffffcc00Level 3|r - \u003CAEfk,DataA3\u003E damage per target. |n|cffffcc00Level 4|r - \u003CAEfk,DataA4\u003E damage per target."
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/ZB05.json
+++ b/mapdata/WarcraftLegacies/AbilityData/ZB05.json
@@ -149,11 +149,6 @@
       "Value": "Q"
     },
     {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "A coil of death that can damage an enemy living unit or heal a friendly Undead unit. |n|n|cffffcc00Level 1|r - Heals for \u003CAUdc,DataA1\u003E hit points. |n|cffffcc00Level 2|r - Heals for \u003CAUdc,DataA2\u003E hit points. |n|cffffcc00Level 3|r - Heals for \u003CAUdc,DataA3\u003E hit points. |n|cffffcc00Level 4|r - Heals for \u003CAUdc,DataA4\u003E hit points."
-    },
-    {
       "Level": 4,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/ZBEU.json
+++ b/mapdata/WarcraftLegacies/AbilityData/ZBEU.json
@@ -61,11 +61,6 @@
       "Value": "AEvi,ZBPA"
     },
     {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Enhances the other Gazlowe abilities with each level learned:|n|n|cffffcc00Cluster Rockets|r - Larger Area.|n|cffffcc00Pocket Factory|r - Builds Clockwerk Goblins more quickly.|n|nAlso gives bonus damage and increases the Tinker\u0027s movement speed.|n|n|cffffcc00Level 1|r - \u002B\u003CANeg,DataB1\u003E damage, \u002B\u003CANeg,DataA1,%\u003E% movement.|n|cffffcc00Level 2|r - \u002B\u003CANeg,DataB2\u003E damage, \u002B\u003CANeg,DataA2,%\u003E% movement.|n|cffffcc00Level 3|r - \u002B\u003CANeg,DataB3\u003E damage, \u002B\u003CANeg,DataA3,%\u003E% movement.|n|cffffcc00Level 4|r - \u002B9 damage, \u002B40% movement."
-    },
-    {
       "Id": "arhk",
       "Type": 3,
       "Value": ""

--- a/mapdata/WarcraftLegacies/AbilityData/ZBFN.json
+++ b/mapdata/WarcraftLegacies/AbilityData/ZBFN.json
@@ -34,49 +34,6 @@
       "Value": 1
     },
     {
-      "Level": 2,
-      "Pointer": 1,
-      "Id": "Ufn1",
-      "Type": 2,
-      "Value": 95
-    },
-    {
-      "Level": 2,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 12
-    },
-    {
-      "Level": 2,
-      "Id": "ahdu",
-      "Type": 2,
-      "Value": 0.01
-    },
-    {
-      "Level": 2,
-      "Id": "adur",
-      "Type": 2,
-      "Value": 0.01
-    },
-    {
-      "Level": 2,
-      "Id": "abuf",
-      "Type": 3,
-      "Value": ""
-    },
-    {
-      "Level": 2,
-      "Pointer": 2,
-      "Id": "Ufn2",
-      "Type": 2,
-      "Value": 80
-    },
-    {
-      "Level": 2,
-      "Id": "amcs",
-      "Value": 100
-    },
-    {
       "Level": 1,
       "Id": "acdn",
       "Type": 2,
@@ -112,18 +69,6 @@
       "Id": "atp1",
       "Type": 3,
       "Value": "Frost Nova"
-    },
-    {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Blasts enemy units with a wave of Driduc Energy that deals \u003CA0CO,DataB2\u003E damage to the target, and \u003CA0CO,DataA2\u003E splash damage. "
-    },
-    {
-      "Level": 2,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Nature\u0027s Fury - [|cffffcc00Level 2|r]"
     },
     {
       "Level": 1,

--- a/mapdata/WarcraftLegacies/AbilityData/ZBFN.json
+++ b/mapdata/WarcraftLegacies/AbilityData/ZBFN.json
@@ -55,16 +55,6 @@
       "Value": "Q"
     },
     {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Frost Nova (|cffffcc00Q|r) - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Blasts enemy units around a target enemy unit with a wave of damaging frost that slows movement and attack rate. |n|n|cffffcc00Level 1|r - 100 target damage, 50 nova damage. |n|cffffcc00Level 2|r - 100 target damage, 100 nova damage. |n|cffffcc00Level 3|r - 100 target damage, 150 nova damage. |n|cffffcc00Level 4|r - 100 target damage, 200 nova damage. |n|cffffcc00Level 5|r - 100 target damage, 250 nova damage."
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/ZBIB.json
+++ b/mapdata/WarcraftLegacies/AbilityData/ZBIB.json
@@ -130,11 +130,6 @@
       "Value": "Ice Block"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTNCosmicFlame.blp"
-    },
-    {
       "Id": "arhk",
       "Type": 3,
       "Value": "Q"

--- a/mapdata/WarcraftLegacies/AbilityData/ZBIB.json
+++ b/mapdata/WarcraftLegacies/AbilityData/ZBIB.json
@@ -12,46 +12,10 @@
       "Value": 125
     },
     {
-      "Level": 2,
-      "Id": "aare",
-      "Type": 2,
-      "Value": 300
-    },
-    {
-      "Level": 3,
-      "Id": "aare",
-      "Type": 2,
-      "Value": 300
-    },
-    {
-      "Level": 4,
-      "Id": "aare",
-      "Type": 2,
-      "Value": 300
-    },
-    {
       "Level": 1,
       "Id": "acdn",
       "Type": 2,
       "Value": 25
-    },
-    {
-      "Level": 2,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 60
-    },
-    {
-      "Level": 3,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 60
-    },
-    {
-      "Level": 4,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 60
     },
     {
       "Level": 1,
@@ -59,21 +23,6 @@
       "Value": 100
     },
     {
-      "Level": 2,
-      "Id": "amcs",
-      "Value": 225
-    },
-    {
-      "Level": 3,
-      "Id": "amcs",
-      "Value": 260
-    },
-    {
-      "Level": 4,
-      "Id": "amcs",
-      "Value": 295
-    },
-    {
       "Level": 1,
       "Pointer": 1,
       "Id": "Ncl1",
@@ -81,46 +30,7 @@
       "Value": 0.5
     },
     {
-      "Level": 2,
-      "Pointer": 1,
-      "Id": "Ncl1",
-      "Type": 2,
-      "Value": 0.5
-    },
-    {
-      "Level": 3,
-      "Pointer": 1,
-      "Id": "Ncl1",
-      "Type": 2,
-      "Value": 0.5
-    },
-    {
-      "Level": 4,
-      "Pointer": 1,
-      "Id": "Ncl1",
-      "Type": 2,
-      "Value": 0.5
-    },
-    {
       "Level": 1,
-      "Pointer": 2,
-      "Id": "Ncl2",
-      "Value": 2
-    },
-    {
-      "Level": 2,
-      "Pointer": 2,
-      "Id": "Ncl2",
-      "Value": 2
-    },
-    {
-      "Level": 3,
-      "Pointer": 2,
-      "Id": "Ncl2",
-      "Value": 2
-    },
-    {
-      "Level": 4,
       "Pointer": 2,
       "Id": "Ncl2",
       "Value": 2
@@ -132,70 +42,13 @@
       "Value": 19
     },
     {
-      "Level": 2,
-      "Pointer": 3,
-      "Id": "Ncl3",
-      "Value": 3
-    },
-    {
-      "Level": 3,
-      "Pointer": 3,
-      "Id": "Ncl3",
-      "Value": 3
-    },
-    {
-      "Level": 4,
-      "Pointer": 3,
-      "Id": "Ncl3",
-      "Value": 3
-    },
-    {
       "Level": 1,
       "Pointer": 5,
       "Id": "Ncl5",
       "Value": 0
     },
     {
-      "Level": 2,
-      "Pointer": 5,
-      "Id": "Ncl5",
-      "Value": 0
-    },
-    {
-      "Level": 3,
-      "Pointer": 5,
-      "Id": "Ncl5",
-      "Value": 0
-    },
-    {
-      "Level": 4,
-      "Pointer": 5,
-      "Id": "Ncl5",
-      "Value": 0
-    },
-    {
       "Level": 1,
-      "Pointer": 6,
-      "Id": "Ncl6",
-      "Type": 3,
-      "Value": "flamestrike"
-    },
-    {
-      "Level": 2,
-      "Pointer": 6,
-      "Id": "Ncl6",
-      "Type": 3,
-      "Value": "flamestrike"
-    },
-    {
-      "Level": 3,
-      "Pointer": 6,
-      "Id": "Ncl6",
-      "Type": 3,
-      "Value": "flamestrike"
-    },
-    {
-      "Level": 4,
       "Pointer": 6,
       "Id": "Ncl6",
       "Type": 3,
@@ -212,24 +65,6 @@
     },
     {
       "Level": 1,
-      "Id": "aran",
-      "Type": 2,
-      "Value": 700
-    },
-    {
-      "Level": 2,
-      "Id": "aran",
-      "Type": 2,
-      "Value": 700
-    },
-    {
-      "Level": 3,
-      "Id": "aran",
-      "Type": 2,
-      "Value": 700
-    },
-    {
-      "Level": 4,
       "Id": "aran",
       "Type": 2,
       "Value": 700
@@ -316,46 +151,10 @@
       "Value": "Ice Block"
     },
     {
-      "Level": 2,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Resurgent Flame Strike - [|cffffcc00Level 2|r]"
-    },
-    {
-      "Level": 3,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Resurgent Flame Strike - [|cffffcc00Level 3|r]"
-    },
-    {
-      "Level": 4,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Resurgent Flame Strike - [|cffffcc00Level 4|r]"
-    },
-    {
       "Level": 1,
       "Id": "aub1",
       "Type": 3,
       "Value": "Freezes ALL units within the target area in a block of ice for \u003CZBrp,Dur1\u003E seconds, preventing them from moving or taking actions but turning them invulnerable. The ice can be dispelled, freeing the units within."
-    },
-    {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Conjures a pillar of flame that burns ground units for \u003CA0F9,DataA2\u003E damage a second for \u003CA0F9,HeroDur2\u003E seconds. The pillar of flame subsides after \u003CA0F9,Dur2\u003E seconds, during which units within continue to take \u003CA0F9,DataC2\u003E damage per second. The first two times the pillar subsides, it resurges again for the same duration."
-    },
-    {
-      "Level": 3,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Conjures a pillar of flame that burns ground units for \u003CA0F9,DataA3\u003E damage a second for \u003CA0F9,HeroDur3\u003E seconds. The pillar of flame subsides after \u003CA0F9,Dur3\u003E seconds, during which units within continue to take \u003CA0F9,DataC3\u003E damage per second. The first two times the pillar subsides, it resurges again for the same duration."
-    },
-    {
-      "Level": 4,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Conjures a pillar of flame that burns ground units for \u003CA0F9,DataA4\u003E damage a second for \u003CA0F9,HeroDur4\u003E seconds. The pillar of flame subsides after \u003CA0F9,Dur4\u003E seconds, during which units within continue to take \u003CA0F9,DataC4\u003E damage per second. The first two times the pillar subsides, it resurges again for the same duration."
     }
   ]
 }

--- a/mapdata/WarcraftLegacies/AbilityData/ZBII.json
+++ b/mapdata/WarcraftLegacies/AbilityData/ZBII.json
@@ -13,27 +13,6 @@
       "Value": 0
     },
     {
-      "Level": 2,
-      "Pointer": 1,
-      "Id": "Eev1",
-      "Type": 2,
-      "Value": 0
-    },
-    {
-      "Level": 3,
-      "Pointer": 1,
-      "Id": "Eev1",
-      "Type": 2,
-      "Value": 0
-    },
-    {
-      "Level": 4,
-      "Pointer": 1,
-      "Id": "Eev1",
-      "Type": 2,
-      "Value": 0
-    },
-    {
       "Id": "alev",
       "Value": 1
     },
@@ -83,46 +62,10 @@
       "Value": "Infinite Influence"
     },
     {
-      "Level": 2,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Hideous Appendages - [|cffffcc00Level 2|r]"
-    },
-    {
-      "Level": 3,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Hideous Appendages - [|cffffcc00Level 3|r]"
-    },
-    {
-      "Level": 4,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Hideous Appendages - [|cffffcc00Level 4|r]"
-    },
-    {
       "Level": 1,
       "Id": "aub1",
       "Type": 3,
       "Value": "This hero can cast its abilities anywhere within 800 units of a hero you control."
-    },
-    {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "N\u0027zoth has 6 Tentacles which attack nearby enemy units autonomously. Each Tentacle has the same attack damage as N\u0027zoth."
-    },
-    {
-      "Level": 3,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "N\u0027zoth has 7 Tentacles which attack nearby enemy units autonomously. Each Tentacle has the same attack damage as N\u0027zoth."
-    },
-    {
-      "Level": 4,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "N\u0027zoth has 8 Tentacles which attack nearby enemy units autonomously. Each Tentacle has the same attack damage as N\u0027zoth."
     },
     {
       "Id": "abpy",

--- a/mapdata/WarcraftLegacies/AbilityData/ZBII.json
+++ b/mapdata/WarcraftLegacies/AbilityData/ZBII.json
@@ -41,21 +41,6 @@
       "Value": "Infinite Influence"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTNTentacles.blp"
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "[|cffffcc00E|r] Learn Hideous Appendages - [|cffffcc00Level %d|r]"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "N\u0027zoth has numerous Tentacles which attack nearby enemy units autonomously. Each Tentacle has the same attack damage as N\u0027zoth. |n|n|cffffcc00Level 1|r - 5 Tentacles. |n|cffffcc00Level 2|r - 6 Tentacles. |n|cffffcc00Level 3|r - 7 Tentacles. |n|cffffcc00Level 3|r - 8 Tentacles."
-    },
-    {
       "Level": 1,
       "Id": "atp1",
       "Type": 3,

--- a/mapdata/WarcraftLegacies/AbilityData/ZBIM.json
+++ b/mapdata/WarcraftLegacies/AbilityData/ZBIM.json
@@ -12,31 +12,7 @@
       "Value": 300
     },
     {
-      "Level": 2,
-      "Id": "aare",
-      "Type": 2,
-      "Value": 300
-    },
-    {
-      "Level": 3,
-      "Id": "aare",
-      "Type": 2,
-      "Value": 300
-    },
-    {
       "Level": 1,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 120
-    },
-    {
-      "Level": 2,
-      "Id": "acdn",
-      "Type": 2,
-      "Value": 120
-    },
-    {
-      "Level": 3,
       "Id": "acdn",
       "Type": 2,
       "Value": 120
@@ -47,31 +23,7 @@
       "Value": 300
     },
     {
-      "Level": 2,
-      "Id": "amcs",
-      "Value": 300
-    },
-    {
-      "Level": 3,
-      "Id": "amcs",
-      "Value": 300
-    },
-    {
       "Level": 1,
-      "Pointer": 1,
-      "Id": "Ncl1",
-      "Type": 2,
-      "Value": 0.5
-    },
-    {
-      "Level": 2,
-      "Pointer": 1,
-      "Id": "Ncl1",
-      "Type": 2,
-      "Value": 0.5
-    },
-    {
-      "Level": 3,
       "Pointer": 1,
       "Id": "Ncl1",
       "Type": 2,
@@ -84,31 +36,7 @@
       "Value": 2
     },
     {
-      "Level": 2,
-      "Pointer": 2,
-      "Id": "Ncl2",
-      "Value": 2
-    },
-    {
-      "Level": 3,
-      "Pointer": 2,
-      "Id": "Ncl2",
-      "Value": 2
-    },
-    {
       "Level": 1,
-      "Pointer": 3,
-      "Id": "Ncl3",
-      "Value": 3
-    },
-    {
-      "Level": 2,
-      "Pointer": 3,
-      "Id": "Ncl3",
-      "Value": 3
-    },
-    {
-      "Level": 3,
       "Pointer": 3,
       "Id": "Ncl3",
       "Value": 3
@@ -120,33 +48,7 @@
       "Value": 0
     },
     {
-      "Level": 2,
-      "Pointer": 5,
-      "Id": "Ncl5",
-      "Value": 0
-    },
-    {
-      "Level": 3,
-      "Pointer": 5,
-      "Id": "Ncl5",
-      "Value": 0
-    },
-    {
       "Level": 1,
-      "Pointer": 6,
-      "Id": "Ncl6",
-      "Type": 3,
-      "Value": "darkconversion"
-    },
-    {
-      "Level": 2,
-      "Pointer": 6,
-      "Id": "Ncl6",
-      "Type": 3,
-      "Value": "darkconversion"
-    },
-    {
-      "Level": 3,
       "Pointer": 6,
       "Id": "Ncl6",
       "Type": 3,
@@ -159,18 +61,6 @@
     },
     {
       "Level": 1,
-      "Id": "aran",
-      "Type": 2,
-      "Value": 99999
-    },
-    {
-      "Level": 2,
-      "Id": "aran",
-      "Type": 2,
-      "Value": 99999
-    },
-    {
-      "Level": 3,
       "Id": "aran",
       "Type": 2,
       "Value": 99999
@@ -272,34 +162,10 @@
       "Value": "Inspire Madness"
     },
     {
-      "Level": 2,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Inspire Madness - [|cffffcc00Level 2|r]"
-    },
-    {
-      "Level": 3,
-      "Id": "atp1",
-      "Type": 3,
-      "Value": "Inspire Madness - [|cffffcc00Level 3|r]"
-    },
-    {
       "Level": 1,
       "Id": "aub1",
       "Type": 3,
       "Value": "Takes control of up to 14 non-summoned enemy units in the target area. Controlled units die after 30 seconds."
-    },
-    {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Takes control of 10 random enemy units in the target area. After 30 seconds, each unit controlled this way dies of madness."
-    },
-    {
-      "Level": 3,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Takes control of 14 random enemy units in the target area. After 30 seconds, each unit controlled this way dies of madness."
     }
   ]
 }

--- a/mapdata/WarcraftLegacies/AbilityData/ZBIM.json
+++ b/mapdata/WarcraftLegacies/AbilityData/ZBIM.json
@@ -127,11 +127,6 @@
       "Value": "Inspire Madness"
     },
     {
-      "Id": "arar",
-      "Type": 3,
-      "Value": "ReplaceableTextures\\CommandButtons\\BTNMind Crush.blp"
-    },
-    {
       "Id": "arpx",
       "Value": 3
     },
@@ -139,16 +134,6 @@
       "Id": "arhk",
       "Type": 3,
       "Value": "R"
-    },
-    {
-      "Id": "aret",
-      "Type": 3,
-      "Value": "Learn Inspire Madness"
-    },
-    {
-      "Id": "arut",
-      "Type": 3,
-      "Value": "Takes control of 14 random enemy units in the target area. After 30 seconds, each unit controlled this way dies."
     },
     {
       "Id": "atat",

--- a/mapdata/WarcraftLegacies/AbilityData/ZBIN.json
+++ b/mapdata/WarcraftLegacies/AbilityData/ZBIN.json
@@ -6,64 +6,10 @@
   ],
   "Modifications": [
     {
-      "Level": 2,
-      "Pointer": 2,
-      "Id": "Nic2",
-      "Type": 2,
-      "Value": 60
-    },
-    {
-      "Level": 3,
-      "Pointer": 2,
-      "Id": "Nic2",
-      "Type": 2,
-      "Value": 80
-    },
-    {
-      "Level": 2,
-      "Pointer": 3,
-      "Id": "Nic3",
-      "Type": 2,
-      "Value": 160
-    },
-    {
-      "Level": 3,
-      "Pointer": 3,
-      "Id": "Nic3",
-      "Type": 2,
-      "Value": 160
-    },
-    {
-      "Level": 2,
-      "Pointer": 4,
-      "Id": "Nic4",
-      "Type": 2,
-      "Value": 45
-    },
-    {
-      "Level": 3,
-      "Pointer": 4,
-      "Id": "Nic4",
-      "Type": 2,
-      "Value": 65
-    },
-    {
       "Level": 1,
       "Id": "adur",
       "Type": 2,
       "Value": 10
-    },
-    {
-      "Level": 2,
-      "Id": "adur",
-      "Type": 2,
-      "Value": 10
-    },
-    {
-      "Level": 3,
-      "Id": "adur",
-      "Type": 2,
-      "Value": 15
     },
     {
       "Id": "aher",
@@ -74,18 +20,6 @@
       "Id": "ahdu",
       "Type": 2,
       "Value": 10
-    },
-    {
-      "Level": 2,
-      "Id": "ahdu",
-      "Type": 2,
-      "Value": 10
-    },
-    {
-      "Level": 3,
-      "Id": "ahdu",
-      "Type": 2,
-      "Value": 15
     },
     {
       "Id": "amho",
@@ -127,18 +61,6 @@
       "Id": "amat",
       "Type": 3,
       "Value": ""
-    },
-    {
-      "Level": 2,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Each attack made is enhanced with living flames that cling to the target. These flames add \u003CA0KC,DataA2\u003E damage on the first attack, twice as much on the second attack, three times as much on the third attack, etc.|n|nIf a unit dies while under this effect, it is incinerated, causing up to \u003CA0KC,DataB2\u003E damage to all nearby hostile units."
-    },
-    {
-      "Level": 3,
-      "Id": "aub1",
-      "Type": 3,
-      "Value": "Each attack made is enhanced with living flames that cling to the target. These flames add \u003CA0KC,DataA3\u003E damage on the first attack, twice as much on the second attack, three times as much on the third attack, etc.|n|nIf a unit dies while under this effect, it is incinerated, causing up to \u003CA0KC,DataB3\u003E damage to all nearby hostile units."
     },
     {
       "Level": 1,


### PR DESCRIPTION
Applies some of the learnings from https://github.com/AzerothWarsLR/WarcraftLegacies/pull/3960. We'd want to automate this in the future, but for now let's just prune the excess

* Removes object modifications that exceed the level of the object
* Removes object modifications that belong to hero abilities on non-hero abilities
 