### PR TITLE
Fixing hardened values and tooltips

### DIFF
--- a/mapdata/WarcraftLegacies/AbilityData/A043.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A043.json
@@ -74,7 +74,7 @@
       "Level": 1,
       "Id": "aub1",
       "Type": 3,
-      "Value": "Heals a friendly living unit for 200 and grants bonus armor, or afflicts an enemy Undead unit with reduced armor dealing half the damage."
+      "Value": "Heals a friendly living unit for 200 and grants \u003CA00G,DataA1\u003E bonus armor, or afflicts an enemy Undead unit with \u003CA00K,DataA1\u003E reduced armor dealing half the damage."
     },
     {
       "Level": 2,

--- a/mapdata/WarcraftLegacies/AbilityData/A0M5.json
+++ b/mapdata/WarcraftLegacies/AbilityData/A0M5.json
@@ -15,7 +15,7 @@
       "Pointer": 3,
       "Id": "Ssk3",
       "Type": 2,
-      "Value": 18
+      "Value": 12
     },
     {
       "Level": 1,

--- a/mapdata/WarcraftLegacies/AbilityData/Unho.json
+++ b/mapdata/WarcraftLegacies/AbilityData/Unho.json
@@ -62,7 +62,7 @@
       "Level": 1,
       "Id": "aub1",
       "Type": 3,
-      "Value": "Attacks against this unithave their damage reduced by \u003CUnho,DataC1\u003E. Attacks cannot be reduced below \u003CUnho,DataB1\u003E damage."
+      "Value": "Attacks against this unit have their damage reduced by \u003CUnho,DataC1\u003E. Attacks cannot be reduced below \u003CUnho,DataB1\u003E damage."
     }
   ]
 }

--- a/mapdata/WarcraftLegacies/AbilityData/VP22.json
+++ b/mapdata/WarcraftLegacies/AbilityData/VP22.json
@@ -1,6 +1,6 @@
 {
   "OldId": "Assk",
-  "NewId": "A0ER",
+  "NewId": "VP22",
   "Unk": [
     0
   ],
@@ -24,7 +24,7 @@
       "Pointer": 3,
       "Id": "Ssk3",
       "Type": 2,
-      "Value": 12
+      "Value": 15
     },
     {
       "Level": 2,
@@ -32,10 +32,6 @@
       "Id": "Ssk3",
       "Type": 2,
       "Value": 12
-    },
-    {
-      "Id": "alev",
-      "Value": 2
     },
     {
       "Id": "arac",
@@ -88,7 +84,7 @@
     {
       "Id": "ansf",
       "Type": 3,
-      "Value": "( Blue - Orc Cavalry)"
+      "Value": "(Legion - Doomguard)"
     },
     {
       "Id": "anam",
@@ -105,7 +101,7 @@
       "Level": 1,
       "Id": "aub1",
       "Type": 3,
-      "Value": "Attacks against this unit have their damage reduced by \u003CA0ER,DataC1\u003E. Attacks cannot be reduced below \u003CA0ER,DataB1\u003E damage."
+      "Value": "Attacks against this unit have their damage reduced by \u003CVP22,DataC1\u003E. Attacks cannot be reduced below \u003CVP22,DataB1\u003E damage."
     },
     {
       "Level": 2,

--- a/mapdata/WarcraftLegacies/UnitData/n0DO.json
+++ b/mapdata/WarcraftLegacies/UnitData/n0DO.json
@@ -8,7 +8,7 @@
     {
       "Id": "uabi",
       "Type": 3,
-      "Value": "A020,A0ER,A0BG,VP10,Aiun"
+      "Value": "A020,VP22,A0BG,VP10,Aiun"
     },
     {
       "Id": "ubld",

--- a/mapdata/WarcraftLegacies/UpgradeData/R00F.json
+++ b/mapdata/WarcraftLegacies/UpgradeData/R00F.json
@@ -61,7 +61,7 @@
       "Level": 1,
       "Id": "gub1",
       "Type": 3,
-      "Value": "Reduces incoming damage from attacks by \u003CA02O,DataC1\u003E for Dwarven Warriors and \u003CVP20,DataC1\u003E for Thanes."
+      "Value": "Equips Dwarven Warriors and Thanes with mithril plating, reducing incoming damage from attacks by \u003CA02O,DataC1\u003E for Dwarven Warriors and \u003CVP20,DataC1\u003E for Thanes."
     }
   ]
 }

--- a/mapdata/WarcraftLegacies/UpgradeData/R03Z.json
+++ b/mapdata/WarcraftLegacies/UpgradeData/R03Z.json
@@ -56,7 +56,7 @@
       "Level": 1,
       "Id": "gub1",
       "Type": 3,
-      "Value": "Gives Felguards and Doomguards a 25% chance for an attack to be absorbed reducing damage taken by 40 damage. Attacks cannot be reduced below 3 damage."
+      "Value": "Equips Felguards and Doomguards with fel war plating, reducing incoming damage from attacks by \u003CA0ER,DataC1\u003E for Felguards and \u003CVP22,DataC1\u003E for Doomguards."
     },
     {
       "Id": "gbpx",


### PR DESCRIPTION
updated tooltip for unholy plating (death knight)
reduced illidari elite from 18 to 12 (no upgrade)
increased war plating for felguard 6 to 12 (requires upgrade)
added new ability for doomguard to use limited values (15)
