### PR TITLE
Second Wind (Muradin) — full-HP handling + heal SFX

### DIFF
--- a/src/WarcraftLegacies.Source/Factions/Ironforge/IronforgeTraits.cs
+++ b/src/WarcraftLegacies.Source/Factions/Ironforge/IronforgeTraits.cs
@@ -40,11 +40,12 @@ public static class IronforgeTraits
         {
           Base = 0f,
           PerLevel = 2f
-        }
+        },
+        HealingEffect = @"Abilities\Spells\Human\Heal\HealTarget.mdl",
+        HealingEffectScale = 1f
       },
       UNIT_HMBR_HIGH_THANE_OF_THE_BRONZEBEARDS_IRONFORGE
     );
-
     UnitTypeTraitRegistry.Register(
       new AvatarOfTheMountain(
         ABILITY_MD07_AVATAR_OF_THE_MOUNTAIN_MURADIN,

--- a/src/WarcraftLegacies.Source/Factions/Ironforge/UnitTraits/SecondWind/SecondWindBuff.cs
+++ b/src/WarcraftLegacies.Source/Factions/Ironforge/UnitTraits/SecondWind/SecondWindBuff.cs
@@ -1,5 +1,6 @@
 ﻿using MacroTools.Extensions;
 using WCSharp.Buffs;
+using WCSharp.Effects;
 
 namespace WarcraftLegacies.Source.Factions.Ironforge.UnitTraits.SecondWind;
 
@@ -8,6 +9,8 @@ public sealed class SecondWindBuff : BoundBuff
   private const float LowHealthThresholdPercent = 40f;
 
   public required float HealPercentPerSecond { private get; init; }
+  public string HealingEffect { private get; init; }
+  public float HealingEffectScale { private get; init; } = 1f;
 
   public SecondWindBuff(unit caster, unit target) : base(caster, target)
   {
@@ -17,13 +20,25 @@ public sealed class SecondWindBuff : BoundBuff
 
   public override void OnTick()
   {
+    if (Target.Life >= Target.MaxLife)
+    {
+      Active = false;
+      return;
+    }
+
     var percent = Target.GetLifePercent() < LowHealthThresholdPercent
       ? HealPercentPerSecond * 2f
       : HealPercentPerSecond;
 
     Target.Life += Target.MaxLife * percent / 100f;
-  }
 
+    if (!string.IsNullOrEmpty(HealingEffect))
+    {
+      effect effect = effect.Create(HealingEffect, Target, "origin");
+      effect.Scale = HealingEffectScale;
+      EffectSystem.Add(effect, 1);
+    }
+  }
   public override void OnDeath(bool killingBlow)
   {
     Active = false;

--- a/src/WarcraftLegacies.Source/Factions/Ironforge/UnitTraits/SecondWind/SecondWindCooldownBuff.cs
+++ b/src/WarcraftLegacies.Source/Factions/Ironforge/UnitTraits/SecondWind/SecondWindCooldownBuff.cs
@@ -6,6 +6,9 @@ public sealed class SecondWindCooldownBuff : PassiveBuff
 {
   public required float HealPercentPerSecond { private get; init; }
 
+  public string HealingEffect { private get; init; }
+  public float HealingEffectScale { private get; init; } = 1f;
+
   public SecondWindCooldownBuff(unit target) : base(target, target)
   {
   }
@@ -17,7 +20,9 @@ public sealed class SecondWindCooldownBuff : PassiveBuff
       Active = true,
       Duration = float.MaxValue,
       IsBeneficial = true,
-      HealPercentPerSecond = HealPercentPerSecond
+      HealPercentPerSecond = HealPercentPerSecond,
+      HealingEffect = HealingEffect,
+      HealingEffectScale = HealingEffectScale
     });
   }
 

--- a/src/WarcraftLegacies.Source/Factions/Ironforge/UnitTraits/SecondWind/SecondWindTrait.cs
+++ b/src/WarcraftLegacies.Source/Factions/Ironforge/UnitTraits/SecondWind/SecondWindTrait.cs
@@ -11,6 +11,8 @@ public sealed class SecondWindTrait : UnitTrait, IEffectOnCreated, IEffectOnDama
 
   public required LeveledAbilityField<float> HealPercentPerSecond { private get; init; }
 
+  public string HealingEffect { private get; init; }
+  public float HealingEffectScale { private get; init; } = 1f;
   public float OutOfCombatThreshold { private get; init; } = 7f;
 
   public SecondWindTrait(int abilityTypeId)
@@ -78,7 +80,9 @@ public sealed class SecondWindTrait : UnitTrait, IEffectOnCreated, IEffectOnDama
       Active = true,
       Duration = OutOfCombatThreshold,
       IsBeneficial = true,
-      HealPercentPerSecond = healPercentPerSecond
+      HealPercentPerSecond = healPercentPerSecond,
+      HealingEffect = HealingEffect,
+      HealingEffectScale = HealingEffectScale
     });
   }
 }


### PR DESCRIPTION
- SecondWindBuff: buff now deactivates once the unit reaches full HP, instead of ticking indefinitely with no effect
- SecondWindBuff: plays a healing special effect (HealingEffect) on the target each tick it actually heals
- SecondWindCooldownBuff / SecondWindTrait: added HealingEffect and HealingEffectScale properties, passed through to SecondWindBuff when the regen buff is created